### PR TITLE
feat(db): Realm to Room migration + CI compile fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.realm)
+    alias(libs.plugins.ksp)
 }
 
 val splitApks = !project.hasProperty("noSplits")
@@ -181,4 +182,12 @@ dependencies {
     implementation(libs.realm.library.base)
     implementation(libs.reorderable)
     implementation(libs.scrollbars)
+
+    // Room — Realm replacement. Kept alongside Realm for one release so the
+    // RealmToRoomMigrator can read the legacy store once. Realm and its
+    // entities will be removed in the next release.
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+    androidTestImplementation(libs.androidx.room.testing)
 }

--- a/app/src/androidTest/java/com/dn0ne/player/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/dn0ne/player/ExampleInstrumentedTest.kt
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.dn0ne.player", appContext.packageName)
+        assertEquals("com.dn0ne.lotus.community", appContext.packageName)
     }
 }

--- a/app/src/androidTest/java/com/dn0ne/player/app/data/db/LyricsDaoTest.kt
+++ b/app/src/androidTest/java/com/dn0ne/player/app/data/db/LyricsDaoTest.kt
@@ -1,0 +1,84 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LyricsDaoTest {
+
+    private lateinit var db: LotusDatabase
+    private lateinit var dao: LyricsDao
+
+    @Before
+    fun setup() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        db = Room.inMemoryDatabaseBuilder(context, LotusDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.lyricsDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun getByUri_returns_inserted_row() = runBlocking {
+        dao.upsert(LyricsEntity(uri = "content://song/1", json = "payload"))
+
+        val row = dao.getByUri("content://song/1")
+        assertEquals("payload", row?.json)
+    }
+
+    @Test
+    fun getByUri_returns_null_for_missing_row() = runBlocking {
+        assertNull(dao.getByUri("content://missing"))
+    }
+
+    @Test
+    fun upsert_replaces_on_same_uri() = runBlocking {
+        dao.upsert(LyricsEntity(uri = "u", json = "first"))
+        dao.upsert(LyricsEntity(uri = "u", json = "second"))
+
+        assertEquals("second", dao.getByUri("u")?.json)
+    }
+
+    @Test
+    fun updateJson_changes_payload() = runBlocking {
+        dao.upsert(LyricsEntity(uri = "u", json = "old"))
+
+        dao.updateJson(uri = "u", json = "new")
+
+        assertEquals("new", dao.getByUri("u")?.json)
+    }
+
+    @Test
+    fun deleteByUri_removes_row() = runBlocking {
+        dao.upsert(LyricsEntity(uri = "u", json = "x"))
+
+        dao.deleteByUri("u")
+
+        assertNull(dao.getByUri("u"))
+    }
+
+    @Test
+    fun upsertAll_then_getAll_returns_all_rows() = runBlocking {
+        dao.upsertAll(
+            listOf(
+                LyricsEntity(uri = "a", json = "1"),
+                LyricsEntity(uri = "b", json = "2"),
+            )
+        )
+
+        assertEquals(2, dao.getAll().size)
+    }
+}

--- a/app/src/androidTest/java/com/dn0ne/player/app/data/db/PlaylistDaoTest.kt
+++ b/app/src/androidTest/java/com/dn0ne/player/app/data/db/PlaylistDaoTest.kt
@@ -1,0 +1,105 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PlaylistDaoTest {
+
+    private lateinit var db: LotusDatabase
+    private lateinit var dao: PlaylistDao
+
+    @Before
+    fun setup() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        db = Room.inMemoryDatabaseBuilder(context, LotusDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.playlistDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun upsert_and_getAll_round_trip() = runBlocking {
+        dao.upsert(PlaylistEntity(name = "mix", json = """{"name":"mix","trackList":[]}"""))
+
+        val rows = dao.getAll()
+        assertEquals(1, rows.size)
+        assertEquals("mix", rows[0].name)
+    }
+
+    @Test
+    fun upsert_replaces_on_same_primary_key() = runBlocking {
+        dao.upsert(PlaylistEntity(name = "mix", json = "first"))
+        dao.upsert(PlaylistEntity(name = "mix", json = "second"))
+
+        val rows = dao.getAll()
+        assertEquals(1, rows.size)
+        assertEquals("second", rows[0].json)
+    }
+
+    @Test
+    fun observeAll_returns_rows_most_recent_first() = runBlocking {
+        dao.upsert(PlaylistEntity(name = "first", json = "{}"))
+        dao.upsert(PlaylistEntity(name = "second", json = "{}"))
+        dao.upsert(PlaylistEntity(name = "third", json = "{}"))
+
+        val rows = dao.observeAll().first()
+        assertEquals(listOf("third", "second", "first"), rows.map { it.name })
+    }
+
+    @Test
+    fun updateJson_changes_payload_not_name() = runBlocking {
+        dao.upsert(PlaylistEntity(name = "mix", json = "old"))
+
+        dao.updateJson(name = "mix", json = "new")
+
+        val rows = dao.getAll()
+        assertEquals(1, rows.size)
+        assertEquals("new", rows[0].json)
+    }
+
+    @Test
+    fun deleteByName_removes_only_matching_row() = runBlocking {
+        dao.upsert(PlaylistEntity(name = "keep", json = "{}"))
+        dao.upsert(PlaylistEntity(name = "drop", json = "{}"))
+
+        dao.deleteByName("drop")
+
+        val rows = dao.getAll()
+        assertEquals(1, rows.size)
+        assertEquals("keep", rows[0].name)
+    }
+
+    @Test
+    fun upsertAll_inserts_all_rows() = runBlocking {
+        dao.upsertAll(
+            listOf(
+                PlaylistEntity(name = "a", json = "{}"),
+                PlaylistEntity(name = "b", json = "{}"),
+            )
+        )
+
+        assertEquals(2, dao.getAll().size)
+    }
+
+    @Test
+    fun getAll_on_empty_returns_empty_list() = runBlocking {
+        assertTrue(dao.getAll().isEmpty())
+        assertNull(dao.getAll().firstOrNull())
+    }
+}

--- a/app/src/androidTest/java/com/dn0ne/player/app/data/db/RealmToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/com/dn0ne/player/app/data/db/RealmToRoomMigratorTest.kt
@@ -1,0 +1,124 @@
+package com.dn0ne.player.app.data.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.dn0ne.player.app.data.repository.LyricsJson
+import com.dn0ne.player.app.data.repository.PlaylistJson
+import com.dn0ne.player.core.data.Settings
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+import io.realm.kotlin.UpdatePolicy
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealmToRoomMigratorTest {
+
+    private lateinit var context: Context
+    private lateinit var db: LotusDatabase
+    private lateinit var settings: Settings
+
+    private val realmConfig by lazy {
+        RealmConfiguration.create(schema = setOf(LyricsJson::class, PlaylistJson::class))
+    }
+
+    @Before
+    fun setup() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+
+        context.getSharedPreferences("settings", Context.MODE_PRIVATE).edit().clear().apply()
+        runCatching { Realm.deleteRealm(realmConfig) }
+
+        db = Room.inMemoryDatabaseBuilder(context, LotusDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        settings = Settings(context)
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        runCatching { Realm.deleteRealm(realmConfig) }
+    }
+
+    @Test
+    fun fresh_install_without_realm_file_marks_migration_done() = runBlocking {
+        val migrator = RealmToRoomMigrator(context, db, settings)
+
+        migrator.migrateIfNeeded()
+
+        assertTrue(settings.realmToRoomMigrationDone)
+        assertTrue(db.playlistDao().getAll().isEmpty())
+        assertTrue(db.lyricsDao().getAll().isEmpty())
+    }
+
+    @Test
+    fun existing_realm_rows_are_copied_to_room() = runBlocking {
+        seedRealm(
+            playlists = listOf("mix-a" to "{json-a}", "mix-b" to "{json-b}"),
+            lyrics = listOf("content://song/1" to "lrc-1", "content://song/2" to "lrc-2"),
+        )
+
+        RealmToRoomMigrator(context, db, settings).migrateIfNeeded()
+
+        val playlists = db.playlistDao().getAll().associate { it.name to it.json }
+        assertEquals(mapOf("mix-a" to "{json-a}", "mix-b" to "{json-b}"), playlists)
+
+        val lyrics = db.lyricsDao().getAll().associate { it.uri to it.json }
+        assertEquals(mapOf("content://song/1" to "lrc-1", "content://song/2" to "lrc-2"), lyrics)
+
+        assertTrue(settings.realmToRoomMigrationDone)
+    }
+
+    @Test
+    fun migration_is_a_noop_after_flag_is_set() = runBlocking {
+        seedRealm(playlists = listOf("original" to "{}"), lyrics = emptyList())
+        RealmToRoomMigrator(context, db, settings).migrateIfNeeded()
+        assertEquals(1, db.playlistDao().getAll().size)
+
+        // Mutate the Room store to something the second run shouldn't touch.
+        db.playlistDao().deleteByName("original")
+
+        RealmToRoomMigrator(context, db, settings).migrateIfNeeded()
+
+        assertTrue(db.playlistDao().getAll().isEmpty())
+    }
+
+    private fun seedRealm(
+        playlists: List<Pair<String, String>>,
+        lyrics: List<Pair<String, String>>,
+    ) {
+        val realm = Realm.open(realmConfig)
+        try {
+            realm.writeBlocking {
+                playlists.forEach { (name, json) ->
+                    copyToRealm(
+                        PlaylistJson().apply {
+                            this.name = name
+                            this.json = json
+                        },
+                        UpdatePolicy.ALL,
+                    )
+                }
+                lyrics.forEach { (uri, json) ->
+                    copyToRealm(
+                        LyricsJson().apply {
+                            this.uri = uri
+                            this.json = json
+                        },
+                        UpdatePolicy.ALL,
+                    )
+                }
+            }
+        } finally {
+            realm.close()
+        }
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/PlayerApp.kt
+++ b/app/src/main/java/com/dn0ne/player/PlayerApp.kt
@@ -1,14 +1,24 @@
 package com.dn0ne.player
 
 import android.app.Application
+import com.dn0ne.player.app.data.db.RealmToRoomMigrator
 import com.dn0ne.player.app.di.playerModule
 import com.dn0ne.player.core.crash.CrashReporter
 import com.dn0ne.player.core.di.appModule
 import com.dn0ne.player.setup.di.setupModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
 class PlayerApp: Application() {
+
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val realmToRoomMigrator: RealmToRoomMigrator by inject()
+
     override fun onCreate() {
         super.onCreate()
 
@@ -19,6 +29,12 @@ class PlayerApp: Application() {
         startKoin {
             androidContext(this@PlayerApp)
             modules(appModule, setupModule, playerModule)
+        }
+
+        // One-shot copy of the legacy Realm store into Room. Off the main
+        // thread, no-op after the first successful run. See RealmToRoomMigrator.
+        applicationScope.launch {
+            realmToRoomMigrator.migrateIfNeeded()
         }
     }
 }

--- a/app/src/main/java/com/dn0ne/player/app/data/db/LotusDatabase.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/LotusDatabase.kt
@@ -1,0 +1,18 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [PlaylistEntity::class, LyricsEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class LotusDatabase : RoomDatabase() {
+    abstract fun playlistDao(): PlaylistDao
+    abstract fun lyricsDao(): LyricsDao
+
+    companion object {
+        const val NAME = "lotus.db"
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/db/LyricsDao.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/LyricsDao.kt
@@ -1,0 +1,28 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface LyricsDao {
+
+    @Query("SELECT * FROM lyrics_cache WHERE uri = :uri LIMIT 1")
+    suspend fun getByUri(uri: String): LyricsEntity?
+
+    @Query("SELECT * FROM lyrics_cache")
+    suspend fun getAll(): List<LyricsEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: LyricsEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(entities: List<LyricsEntity>)
+
+    @Query("UPDATE lyrics_cache SET json = :json WHERE uri = :uri")
+    suspend fun updateJson(uri: String, json: String)
+
+    @Query("DELETE FROM lyrics_cache WHERE uri = :uri")
+    suspend fun deleteByUri(uri: String)
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/db/LyricsEntity.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/LyricsEntity.kt
@@ -1,0 +1,18 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Mirrors the legacy Realm `LyricsJson` schema one-to-one. The `json` column
+ * holds the serialized `Lyrics` domain object.
+ */
+@Entity(tableName = "lyrics_cache")
+data class LyricsEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "uri")
+    val uri: String,
+    @ColumnInfo(name = "json")
+    val json: String,
+)

--- a/app/src/main/java/com/dn0ne/player/app/data/db/PlaylistDao.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/PlaylistDao.kt
@@ -1,0 +1,30 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PlaylistDao {
+
+    /** Most-recently-inserted first, matching the original Realm behaviour. */
+    @Query("SELECT * FROM playlists ORDER BY ROWID DESC")
+    fun observeAll(): Flow<List<PlaylistEntity>>
+
+    @Query("SELECT * FROM playlists")
+    suspend fun getAll(): List<PlaylistEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: PlaylistEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(entities: List<PlaylistEntity>)
+
+    @Query("UPDATE playlists SET json = :json WHERE name = :name")
+    suspend fun updateJson(name: String, json: String)
+
+    @Query("DELETE FROM playlists WHERE name = :name")
+    suspend fun deleteByName(name: String)
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/db/PlaylistEntity.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/PlaylistEntity.kt
@@ -1,0 +1,21 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Mirrors the legacy Realm `PlaylistJson` schema one-to-one so the
+ * RealmToRoomMigrator can copy rows verbatim. The `json` column holds the
+ * serialized `Playlist` domain object — we intentionally keep the JSON-blob
+ * shape rather than decomposing into columns so the migration is mechanical
+ * and the serialization format stays the single source of truth.
+ */
+@Entity(tableName = "playlists")
+data class PlaylistEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "name")
+    val name: String,
+    @ColumnInfo(name = "json")
+    val json: String,
+)

--- a/app/src/main/java/com/dn0ne/player/app/data/db/RealmToRoomMigrator.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/RealmToRoomMigrator.kt
@@ -1,0 +1,76 @@
+package com.dn0ne.player.app.data.db
+
+import android.content.Context
+import android.util.Log
+import com.dn0ne.player.app.data.repository.LyricsJson
+import com.dn0ne.player.app.data.repository.PlaylistJson
+import com.dn0ne.player.core.data.Settings
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+import io.realm.kotlin.ext.query
+import java.io.File
+
+/**
+ * One-shot copy of the legacy Realm stores (PlaylistJson, LyricsJson) into
+ * the Room equivalents. The JSON-blob shape is identical on both sides so
+ * this is purely a row copy — no decoding / re-encoding of domain objects.
+ *
+ * Runs off the main thread from PlayerApp.onCreate. Failures are logged and
+ * swallowed so a corrupt Realm file can't block app startup; worst case the
+ * user loses their playlists and lyrics cache (both re-creatable) instead of
+ * the app being bricked.
+ */
+class RealmToRoomMigrator(
+    private val context: Context,
+    private val database: LotusDatabase,
+    private val settings: Settings,
+) {
+
+    suspend fun migrateIfNeeded() {
+        if (settings.realmToRoomMigrationDone) return
+
+        // Fresh installs have no Realm file; don't create one just to read
+        // zero rows out of it. Mark done and move on.
+        if (!realmFileExists()) {
+            settings.realmToRoomMigrationDone = true
+            return
+        }
+
+        var realm: Realm? = null
+        try {
+            val configuration = RealmConfiguration.create(
+                schema = setOf(LyricsJson::class, PlaylistJson::class),
+            )
+            realm = Realm.open(configuration)
+
+            val playlists = realm.query<PlaylistJson>().find()
+                .map { PlaylistEntity(name = it.name, json = it.json) }
+            if (playlists.isNotEmpty()) {
+                database.playlistDao().upsertAll(playlists)
+            }
+
+            val lyrics = realm.query<LyricsJson>().find()
+                .map { LyricsEntity(uri = it.uri, json = it.json) }
+            if (lyrics.isNotEmpty()) {
+                database.lyricsDao().upsertAll(lyrics)
+            }
+
+            settings.realmToRoomMigrationDone = true
+            Log.i(TAG, "Migrated ${playlists.size} playlists and ${lyrics.size} lyrics entries.")
+        } catch (t: Throwable) {
+            Log.e(TAG, "Realm → Room migration failed; will retry on next launch.", t)
+        } finally {
+            realm?.close()
+        }
+    }
+
+    private fun realmFileExists(): Boolean =
+        File(context.filesDir, DEFAULT_REALM_NAME).exists()
+
+    private companion object {
+        const val TAG = "RealmToRoomMigrator"
+        // Realm Kotlin SDK's default filename when no `name` is set on the
+        // RealmConfiguration.
+        const val DEFAULT_REALM_NAME = "default.realm"
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/LyricsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/LyricsRepository.kt
@@ -3,7 +3,7 @@ package com.dn0ne.player.app.data.repository
 import com.dn0ne.player.app.domain.lyrics.Lyrics
 
 interface LyricsRepository {
-    fun getLyricsByUri(uri: String): Lyrics?
+    suspend fun getLyricsByUri(uri: String): Lyrics?
     suspend fun insertLyrics(lyrics: Lyrics)
     suspend fun updateLyrics(lyrics: Lyrics)
     suspend fun deleteLyrics(lyrics: Lyrics)

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/RealmLyricsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/RealmLyricsRepository.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.Json
 class RealmLyricsRepository(
     private val realm: Realm
 ): LyricsRepository {
-    override fun getLyricsByUri(uri: String): Lyrics? {
+    override suspend fun getLyricsByUri(uri: String): Lyrics? {
         return realm.query<LyricsJson>("uri = $0", uri).find().firstOrNull()?.toLyrics()
     }
 

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/RoomLyricsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/RoomLyricsRepository.kt
@@ -1,0 +1,33 @@
+package com.dn0ne.player.app.data.repository
+
+import com.dn0ne.player.app.data.db.LyricsDao
+import com.dn0ne.player.app.data.db.LyricsEntity
+import com.dn0ne.player.app.domain.lyrics.Lyrics
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Room-backed replacement for RealmLyricsRepository. Same JSON-blob shape
+ * as the legacy Realm store so the migrator can copy rows verbatim.
+ */
+class RoomLyricsRepository(
+    private val dao: LyricsDao,
+) : LyricsRepository {
+
+    override suspend fun getLyricsByUri(uri: String): Lyrics? =
+        dao.getByUri(uri)?.toLyrics()
+
+    override suspend fun insertLyrics(lyrics: Lyrics) {
+        dao.upsert(LyricsEntity(uri = lyrics.uri, json = Json.encodeToString(lyrics)))
+    }
+
+    override suspend fun updateLyrics(lyrics: Lyrics) {
+        dao.updateJson(uri = lyrics.uri, json = Json.encodeToString(lyrics))
+    }
+
+    override suspend fun deleteLyrics(lyrics: Lyrics) {
+        dao.deleteByUri(lyrics.uri)
+    }
+}
+
+private fun LyricsEntity.toLyrics(): Lyrics = Json.decodeFromString(json)

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/RoomPlaylistRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/RoomPlaylistRepository.kt
@@ -1,0 +1,46 @@
+package com.dn0ne.player.app.data.repository
+
+import com.dn0ne.player.app.data.db.PlaylistDao
+import com.dn0ne.player.app.data.db.PlaylistEntity
+import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.domain.track.Track
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Room-backed replacement for RealmPlaylistRepository. Preserves the
+ * JSON-blob storage shape so upgrading users see their existing playlists
+ * after the one-shot RealmToRoomMigrator copies rows over.
+ */
+class RoomPlaylistRepository(
+    private val dao: PlaylistDao,
+) : PlaylistRepository {
+
+    override fun getPlaylists(): Flow<List<Playlist>> =
+        dao.observeAll().map { rows -> rows.map { it.toPlaylist() } }
+
+    override suspend fun insertPlaylist(playlist: Playlist) {
+        val name = playlist.name ?: return
+        dao.upsert(PlaylistEntity(name = name, json = Json.encodeToString(playlist)))
+    }
+
+    override suspend fun updatePlaylistTrackList(playlist: Playlist, trackList: List<Track>) {
+        val name = playlist.name ?: return
+        val updated = playlist.copy(trackList = trackList)
+        dao.updateJson(name = name, json = Json.encodeToString(updated))
+    }
+
+    override suspend fun renamePlaylist(playlist: Playlist, name: String) {
+        deletePlaylist(playlist)
+        insertPlaylist(playlist.copy(name = name))
+    }
+
+    override suspend fun deletePlaylist(playlist: Playlist) {
+        val name = playlist.name ?: return
+        dao.deleteByName(name)
+    }
+}
+
+private fun PlaylistEntity.toPlaylist(): Playlist = Json.decodeFromString(json)

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -1,21 +1,24 @@
 package com.dn0ne.player.app.di
 
+import androidx.room.Room
 import com.dn0ne.player.EqualizerController
 import com.dn0ne.player.app.data.LyricsReader
 import com.dn0ne.player.app.data.LyricsReaderImpl
 import com.dn0ne.player.app.data.MetadataWriter
 import com.dn0ne.player.app.data.MetadataWriterImpl
 import com.dn0ne.player.app.data.SavedPlayerState
+import com.dn0ne.player.app.data.db.LotusDatabase
+import com.dn0ne.player.app.data.db.LyricsDao
+import com.dn0ne.player.app.data.db.PlaylistDao
+import com.dn0ne.player.app.data.db.RealmToRoomMigrator
 import com.dn0ne.player.app.data.remote.lyrics.LrclibLyricsProvider
 import com.dn0ne.player.app.data.remote.lyrics.LyricsProvider
 import com.dn0ne.player.app.data.remote.metadata.MetadataProvider
 import com.dn0ne.player.app.data.remote.metadata.MusicBrainzMetadataProvider
-import com.dn0ne.player.app.data.repository.LyricsJson
 import com.dn0ne.player.app.data.repository.LyricsRepository
-import com.dn0ne.player.app.data.repository.PlaylistJson
 import com.dn0ne.player.app.data.repository.PlaylistRepository
-import com.dn0ne.player.app.data.repository.RealmLyricsRepository
-import com.dn0ne.player.app.data.repository.RealmPlaylistRepository
+import com.dn0ne.player.app.data.repository.RoomLyricsRepository
+import com.dn0ne.player.app.data.repository.RoomPlaylistRepository
 import com.dn0ne.player.app.data.repository.TrackRepository
 import com.dn0ne.player.app.data.repository.TrackRepositoryImpl
 import com.dn0ne.player.app.presentation.PlayerViewModel
@@ -24,8 +27,6 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
-import io.realm.kotlin.Realm
-import io.realm.kotlin.RealmConfiguration
 import kotlinx.serialization.json.Json
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
@@ -79,24 +80,30 @@ val playerModule = module {
         )
     }
 
-    single<Realm> {
-        val configuration = RealmConfiguration.create(
-            schema = setOf(LyricsJson::class, PlaylistJson::class)
-        )
+    single<LotusDatabase> {
+        Room.databaseBuilder(
+            androidContext(),
+            LotusDatabase::class.java,
+            LotusDatabase.NAME,
+        ).build()
+    }
+    single<PlaylistDao> { get<LotusDatabase>().playlistDao() }
+    single<LyricsDao> { get<LotusDatabase>().lyricsDao() }
 
-        Realm.open(configuration)
+    single<RealmToRoomMigrator> {
+        RealmToRoomMigrator(
+            context = androidContext(),
+            database = get(),
+            settings = get(),
+        )
     }
 
     single<LyricsRepository> {
-        RealmLyricsRepository(
-            realm = get()
-        )
+        RoomLyricsRepository(dao = get())
     }
 
     single<PlaylistRepository> {
-        RealmPlaylistRepository(
-            realm = get()
-        )
+        RoomPlaylistRepository(dao = get())
     }
 
     single<EqualizerController> {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/LyricsSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/LyricsSheet.kt
@@ -176,7 +176,7 @@ fun LyricsSheet(
                     )
 
                     val synced = showSyncedLyrics
-                    if (lyrics?.synced != null && lyrics.plain != null && synced != null) {
+                    if (lyrics?.synced != null && lyrics?.plain != null && synced != null) {
                         LyricsTypeSwitch(
                             isSynced = synced,
                             onIsSyncedSwitch = {

--- a/app/src/main/java/com/dn0ne/player/core/data/Settings.kt
+++ b/app/src/main/java/com/dn0ne/player/core/data/Settings.kt
@@ -56,6 +56,8 @@ class Settings(context: Context) {
 
     private val gridPlaylistsKey = "grid-playlists"
 
+    private val realmToRoomMigrationDoneKey = "realm-to-room-migration-done"
+
     var handleAudioFocus: Boolean
         get() = sharedPreferences.getBoolean(handleAudioFocusKey, true)
         set(value) {
@@ -387,4 +389,19 @@ class Settings(context: Context) {
             apply()
         }
     }
+
+    /**
+     * Set once the one-shot Realm → Room copy completes successfully. Guards
+     * against re-running the migration (which would be idempotent thanks to
+     * REPLACE on primary keys, but still wasteful) and lets us drop the Realm
+     * dependency entirely in the next release.
+     */
+    var realmToRoomMigrationDone: Boolean
+        get() = sharedPreferences.getBoolean(realmToRoomMigrationDoneKey, false)
+        set(value) {
+            with(sharedPreferences.edit()) {
+                putBoolean(realmToRoomMigrationDoneKey, value)
+                apply()
+            }
+        }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ jaudiotagger = "3.0.1"
 scrollbars = "2.2.0"
 detekt = "1.23.7"
 ktlint = "12.1.2"
+room = "2.7.1"
+ksp = "2.0.20-1.0.25"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -61,6 +63,10 @@ realm-library-base = { group = "io.realm.kotlin", name = "library-base", version
 reorderable = { group = "sh.calvin.reorderable", name = "reorderable", version.ref = "reorderable" }
 jaudiotagger = { group = "net.jthink", name = "jaudiotagger", version.ref = "jaudiotagger" }
 scrollbars = { group = "com.github.nanihadesuka", name = "LazyColumnScrollbar", version.ref = "scrollbars" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -70,3 +76,4 @@ kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", vers
 realm = { id = "io.realm.kotlin", version.ref = "realm" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary
- Replaces the Realm-backed `PlaylistRepository` / `LyricsRepository` with Room-backed implementations. On first launch after upgrade, `RealmToRoomMigrator` copies existing rows (same JSON-blob shape) off the main thread and sets a SharedPreferences flag so the migration is idempotent; fresh installs never open Realm. Realm dep is kept for one release so the migrator can read the legacy store — the unused Realm repos will be deleted in the next release.
- `LyricsRepository.getLyricsByUri` is now `suspend` (both callers already ran in coroutine scopes, so no caller churn).
- Fixes a compile break in `LyricsSheet.kt` that tanked CI on PR #1's last push — smart-cast doesn't apply to the delegated `lyrics by remember { derivedStateOf { ... } }` property, so `lyrics.plain` had to stay `lyrics?.plain`.

## Test plan
- [ ] CI: `testDebugUnitTest`, `assembleDebug`, `assembleRelease`, `lintRelease` all green
- [ ] Existing-user upgrade: install this on top of a device with playlists + cached lyrics, confirm they're visible after the first launch
- [ ] Fresh install: no `default.realm` file is created in `filesDir`
- [ ] Playlist CRUD (create / rename / delete / reorder tracks) writes to Room and survives app restart
- [ ] Lyrics: a track with cached LRC still shows synced lyrics; a new track fetches from LRCLIB and caches in Room
- [ ] Instrumented tests (`./gradlew connectedDebugAndroidTest`) pass: `PlaylistDaoTest`, `LyricsDaoTest`, `RealmToRoomMigratorTest`

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp