### PR TITLE
fix(build): resolve detekt DSL accessor in subprojects — unblocks CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,11 @@ subprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
-    detekt {
+    // Type-safe accessor (`detekt { ... }`) isn't generated for plugins
+    // applied imperatively inside `subprojects { }`, only for plugins in
+    // the root `plugins { }` block. Use the extension type directly, same
+    // pattern as the ktlint block below.
+    configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
         buildUponDefaultConfig = true
         ignoreFailures = true
         autoCorrect = false


### PR DESCRIPTION
## Summary
Unblocks CI. The root `build.gradle.kts` used the type-safe `detekt { ... }` accessor inside a `subprojects { }` block, but that accessor is only generated when the plugin is applied in the same script's `plugins { }` block. Here detekt is declared `apply false` and then applied imperatively, so Gradle's DSL script compilation was failing with:

```
e: build.gradle.kts:18:5: Unresolved reference: detekt
e: build.gradle.kts:19:9: Unresolved reference: buildUponDefaultConfig
e: build.gradle.kts:20:9: Unresolved reference: ignoreFailures
e: build.gradle.kts:21:9: Unresolved reference: autoCorrect
```

The build was dying ~12s in, during Kotlin DSL script evaluation — before any Android source compilation or tests could run. That's why the earlier failures showed only a bare `ExecutorPolicy` stack trace and no kotlinc errors: the error wasn't in the app sources, it was in the build script itself. Room 2.6.1 vs 2.7.1 was never the issue.

Switches the `detekt { ... }` block to `configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> { ... }`, matching the pattern already used for ktlint right below it.

One file, +5 −1.

## Why this was hard to find
The preceding CI change (commit `062502a`) added a "Dump unit test reports on failure" step that now also captures the full Gradle `--info` output and greps for kotlinc `e:` / `error:` lines. That's what finally surfaced the actual unresolved-reference errors. Without it we were stuck staring at `BUILD FAILED in 12s` with no Caused-by.

## Test plan
- [ ] CI `Unit tests` step completes green
- [ ] `Assemble debug APK`, `Assemble release APK`, `Android lint`, `detekt + ktlint` all green
- [ ] No changes to runtime behavior — this is purely a build-script syntax fix

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp