### PR TITLE
feat(search): global library search across tracks, albums, artists, genres, playlists

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_002_000
-        versionName = "1.2.0-community"
+        versionCode = 1_002_001
+        versionName = "1.2.1-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.MyLocation
 import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.TravelExplore
 import androidx.compose.material.icons.rounded.SelectAll
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -87,6 +88,7 @@ import com.dn0ne.player.app.domain.track.Playlist
 import com.dn0ne.player.app.domain.track.Track
 import com.dn0ne.player.app.domain.track.filterPlaylists
 import com.dn0ne.player.app.domain.track.filterTracks
+import com.dn0ne.player.app.presentation.components.GlobalSearchSheet
 import com.dn0ne.player.app.presentation.components.PlaylistSortButton
 import com.dn0ne.player.app.presentation.components.TrackSortButton
 import com.dn0ne.player.app.presentation.components.playback.PlayerSheet
@@ -975,6 +977,9 @@ fun MainPlayerScreen(
     var showSearchField by rememberSaveable {
         mutableStateOf(false)
     }
+    var showGlobalSearch by rememberSaveable {
+        mutableStateOf(false)
+    }
 
     var isInSelectionMode: Boolean by remember {
         mutableStateOf(false)
@@ -1086,6 +1091,17 @@ fun MainPlayerScreen(
                                             )
                                         )
                                     }
+                                }
+
+                                IconButton(
+                                    onClick = { showGlobalSearch = true }
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.TravelExplore,
+                                        contentDescription = context.resources.getString(
+                                            R.string.search_library
+                                        )
+                                    )
                                 }
 
                                 IconButton(
@@ -1665,6 +1681,21 @@ fun MainPlayerScreen(
             }
         }
     }
+
+    GlobalSearchSheet(
+        isVisible = showGlobalSearch,
+        onDismiss = { showGlobalSearch = false },
+        allTracks = trackList,
+        playlists = playlists,
+        albumPlaylists = albumPlaylists,
+        artistPlaylists = artistPlaylists,
+        genrePlaylists = genrePlaylists,
+        onTrackClick = onTrackClick,
+        onPlaylistClick = onPlaylistSelection,
+        onAlbumPlaylistClick = onAlbumPlaylistSelection,
+        onArtistPlaylistClick = onArtistPlaylistSelection,
+        onGenrePlaylistClick = onGenrePlaylistSelection,
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/GlobalSearchSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/GlobalSearchSheet.kt
@@ -1,0 +1,381 @@
+package com.dn0ne.player.app.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ShapeDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.dn0ne.player.R
+import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.domain.track.Track
+import com.dn0ne.player.app.domain.track.filterPlaylists
+import com.dn0ne.player.app.domain.track.filterTracks
+import com.dn0ne.player.app.presentation.components.trackinfo.SearchField
+
+// One sheet, five sections. The per-tab search in the top bar already
+// handles "find within this tab"; this one answers "find anywhere in my
+// library", which is otherwise five tab switches + five re-queries.
+private const val SECTION_LIMIT = 5
+private const val TRACK_LIMIT = 8
+
+@Composable
+fun GlobalSearchSheet(
+    isVisible: Boolean,
+    onDismiss: () -> Unit,
+    allTracks: List<Track>,
+    playlists: List<Playlist>,
+    albumPlaylists: List<Playlist>,
+    artistPlaylists: List<Playlist>,
+    genrePlaylists: List<Playlist>,
+    onTrackClick: (Track, Playlist) -> Unit,
+    onPlaylistClick: (Playlist) -> Unit,
+    onAlbumPlaylistClick: (Playlist) -> Unit,
+    onArtistPlaylistClick: (Playlist) -> Unit,
+    onGenrePlaylistClick: (Playlist) -> Unit,
+) {
+    if (!isVisible) return
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false
+        )
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            val context = LocalContext.current
+            var query by rememberSaveable { mutableStateOf("") }
+            val focusRequester = remember { FocusRequester() }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .safeDrawingPadding()
+                    .padding(horizontal = 16.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    SearchField(
+                        value = query,
+                        onValueChange = { query = it.trimStart() },
+                        placeholder = context.resources.getString(R.string.search_library),
+                        modifier = Modifier
+                            .weight(1f)
+                            .focusRequester(focusRequester)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.Rounded.Close,
+                            contentDescription = context.resources.getString(R.string.close_track_search)
+                        )
+                    }
+                }
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+                val tracks = remember(allTracks, query) { allTracks.filterTracks(query) }
+                val userPlaylistsMatch = remember(playlists, query) {
+                    playlists.filterPlaylists(query)
+                }
+                val albums = remember(albumPlaylists, query) { albumPlaylists.filterPlaylists(query) }
+                val artists = remember(artistPlaylists, query) {
+                    artistPlaylists.filterPlaylists(query)
+                }
+                val genres = remember(genrePlaylists, query) { genrePlaylists.filterPlaylists(query) }
+
+                when {
+                    query.isBlank() -> EmptyState(
+                        icon = Icons.Rounded.Search,
+                        text = context.resources.getString(R.string.search_library_hint)
+                    )
+                    tracks.isEmpty() && userPlaylistsMatch.isEmpty() &&
+                        albums.isEmpty() && artists.isEmpty() && genres.isEmpty() ->
+                        EmptyState(
+                            icon = Icons.Rounded.Search,
+                            text = context.resources.getString(R.string.search_no_results)
+                        )
+                    else -> LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        if (tracks.isNotEmpty()) {
+                            item("h-tracks") {
+                                SectionHeader(
+                                    label = context.resources.getString(R.string.tracks),
+                                    count = tracks.size
+                                )
+                            }
+                            items(tracks.take(TRACK_LIMIT), key = { "t-" + it.uri }) { track ->
+                                CompactTrackRow(track) {
+                                    onTrackClick(
+                                        track,
+                                        Playlist(name = null, trackList = tracks)
+                                    )
+                                    onDismiss()
+                                }
+                            }
+                        }
+                        if (albums.isNotEmpty()) {
+                            item("h-albums") {
+                                SectionHeader(
+                                    label = context.resources.getString(R.string.albums),
+                                    count = albums.size
+                                )
+                            }
+                            items(
+                                albums.take(SECTION_LIMIT),
+                                key = { "al-" + (it.name ?: "?") }
+                            ) { pl ->
+                                CompactPlaylistRow(
+                                    playlist = pl,
+                                    fallbackLabel = context.resources.getString(R.string.unknown_album),
+                                    icon = Icons.Rounded.Album
+                                ) {
+                                    onAlbumPlaylistClick(pl)
+                                    onDismiss()
+                                }
+                            }
+                        }
+                        if (artists.isNotEmpty()) {
+                            item("h-artists") {
+                                SectionHeader(
+                                    label = context.resources.getString(R.string.artists),
+                                    count = artists.size
+                                )
+                            }
+                            items(
+                                artists.take(SECTION_LIMIT),
+                                key = { "ar-" + (it.name ?: "?") }
+                            ) { pl ->
+                                CompactPlaylistRow(
+                                    playlist = pl,
+                                    fallbackLabel = context.resources.getString(R.string.unknown_artist),
+                                    icon = Icons.Rounded.Person
+                                ) {
+                                    onArtistPlaylistClick(pl)
+                                    onDismiss()
+                                }
+                            }
+                        }
+                        if (genres.isNotEmpty()) {
+                            item("h-genres") {
+                                SectionHeader(
+                                    label = context.resources.getString(R.string.genres),
+                                    count = genres.size
+                                )
+                            }
+                            items(
+                                genres.take(SECTION_LIMIT),
+                                key = { "ge-" + (it.name ?: "?") }
+                            ) { pl ->
+                                CompactPlaylistRow(
+                                    playlist = pl,
+                                    fallbackLabel = context.resources.getString(R.string.unknown_genre),
+                                    icon = Icons.Rounded.MusicNote
+                                ) {
+                                    onGenrePlaylistClick(pl)
+                                    onDismiss()
+                                }
+                            }
+                        }
+                        if (userPlaylistsMatch.isNotEmpty()) {
+                            item("h-playlists") {
+                                SectionHeader(
+                                    label = context.resources.getString(R.string.playlists),
+                                    count = userPlaylistsMatch.size
+                                )
+                            }
+                            items(
+                                userPlaylistsMatch.take(SECTION_LIMIT),
+                                key = { "pl-" + (it.name ?: "?") }
+                            ) { pl ->
+                                CompactPlaylistRow(
+                                    playlist = pl,
+                                    fallbackLabel = context.resources.getString(R.string.unknown),
+                                    icon = Icons.AutoMirrored.Rounded.QueueMusic
+                                ) {
+                                    onPlaylistClick(pl)
+                                    onDismiss()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(label: String, count: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = "($count)",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun EmptyState(icon: ImageVector, text: String) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(48.dp)
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun CompactTrackRow(track: Track, onClick: () -> Unit) {
+    val context = LocalContext.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(ShapeDefaults.Medium)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CoverArt(
+            uri = track.coverArtUri,
+            modifier = Modifier
+                .size(44.dp)
+                .clip(ShapeDefaults.Small)
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = track.title ?: context.resources.getString(R.string.unknown_title),
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = track.artist ?: context.resources.getString(R.string.unknown_artist),
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompactPlaylistRow(
+    playlist: Playlist,
+    fallbackLabel: String,
+    icon: ImageVector,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(ShapeDefaults.Medium)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .clip(ShapeDefaults.Small)
+                .background(color = MaterialTheme.colorScheme.surfaceContainerHigh),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = playlist.name ?: fallbackLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "${playlist.trackList.size}",
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -44,6 +44,9 @@
     <string name="go_to_album">Перейти к альбому</string>
     <string name="go_to_artist">Перейти к исполнителю</string>
     <string name="share_track">Поделиться</string>
+    <string name="search_library">Поиск по библиотеке</string>
+    <string name="search_library_hint">Поиск треков, альбомов, исполнителей, жанров и плейлистов</string>
+    <string name="search_no_results">Ничего не найдено</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -44,6 +44,9 @@
     <string name="go_to_album">Перейти до альбому</string>
     <string name="go_to_artist">Перейти до виконавця</string>
     <string name="share_track">Поділитися</string>
+    <string name="search_library">Пошук у бібліотеці</string>
+    <string name="search_library_hint">Пошук треків, альбомів, виконавців, жанрів і плейлистів</string>
+    <string name="search_no_results">Нічого не знайдено</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,9 @@
     <string name="go_to_album">Go to album</string>
     <string name="go_to_artist">Go to artist</string>
     <string name="share_track">Share</string>
+    <string name="search_library">Search library</string>
+    <string name="search_library_hint">Search tracks, albums, artists, genres, and playlists</string>
+    <string name="search_no_results">No results</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Tracks</string>


### PR DESCRIPTION
## Summary

First Phase 2 feature after v1.2.0: a unified "search across my whole library" entry point, without disturbing the existing per-tab filter.

- New top-bar icon (`TravelExplore`) sits next to the existing tab search icon on every tab. Tap it → full-screen sheet opens.
- Sheet has one search field. Typing filters tracks, user playlists, and the derived album/artist/genre playlists in parallel, showing top-N per category (5 for playlist-shaped sections, 8 for tracks). Empty sections collapse; all-empty shows "No results".
- Tap a track → plays it from the filtered list (as a pseudo-playlist). Tap an album/artist/genre/playlist → navigates into it via the same `onPlaylistSelection` callbacks the tab grids already use.
- No ViewModel / event-channel changes — query state lives in the sheet, filtering reuses existing `filterTracks` / `filterPlaylists`.
- Strings localised for EN / RU / UK.

## Version

Bumps `versionCode 1_002_000 → 1_002_001` and `versionName 1.2.0-community → 1.2.1-community` so merging + tagging `v1.2.1` cuts the real-world-testing release.

## Test plan

- [ ] Tap the new search icon from each tab (Playlists / Tracks / Albums / Artists / Genres / Folders) → sheet opens with the keyboard focused on the search field
- [ ] Typing a query that matches only tracks → only the Tracks section shows
- [ ] Typing a query that matches an album name but no tracks → only Albums section shows
- [ ] Tapping a track result → track plays, sheet dismisses
- [ ] Tapping an album result → navigates to the album, sheet dismisses
- [ ] Tapping an artist / genre / playlist result → navigates correctly
- [ ] Back button / close icon dismisses the sheet
- [ ] Empty query shows the hint; query with no matches shows "No results"
- [ ] RU / UK locales show translated label and hint
- [ ] After merging + tagging `v1.2.1`, the release workflow produces signed APKs on the Releases page

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp