### PR TITLE
feat(playlist): export to M3U + remove upstream-pointing references (v1.2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ The original upstream build (different application ID) is still on
 [upstream releases page](https://github.com/dn0ne/lotus/releases/latest) —
 those are *not* produced by this fork.
 
-## Support
-If you enjoy using Lotus, consider [buying me a coffee](https://en.liberapay.com/dn0ne/donate)!
+## Support the original author
+
+This community fork exists because of the original Lotus by **dn0ne**. If
+you'd like to thank them for the underlying app, you can do so on
+[Liberapay](https://en.liberapay.com/dn0ne/donate). This fork does not
+solicit donations of its own.
 
 ## Build
 1. **Get the Source Code**  

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_002_001
-        versionName = "1.2.1-community"
+        versionCode = 1_002_002
+        versionName = "1.2.2-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/LrclibLyricsProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/LrclibLyricsProvider.kt
@@ -37,8 +37,10 @@ class LrclibLyricsProvider(
 ) : LyricsProvider {
     private val lrclibEndpoint = "https://lrclib.net/api"
     private val logTag = "LrclibLyricsProvider"
+    // LRCLIB requests an identifying User-Agent with a contact URL so rate-limit
+    // / abuse issues can be routed to the right place.
     private val userAgent =
-        "${context.resources.getString(R.string.app_name)}/${context.getAppVersionName()} ( dev.dn0ne@gmail.com )"
+        "${context.resources.getString(R.string.app_name)}/${context.getAppVersionName()} ( https://github.com/Bjorn99/lotus )"
 
     override suspend fun getLyrics(track: Track): Result<Lyrics, DataError.Network> {
         if (track.title == null || track.artist == null) {

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/metadata/MusicBrainzMetadataProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/metadata/MusicBrainzMetadataProvider.kt
@@ -32,8 +32,10 @@ class MusicBrainzMetadataProvider(
     private val logTag = "MBMetadataProvider"
     private val musicBrainzEndpoint = "https://musicbrainz.org/ws/2"
     private val coverArtArchiveEndpoint = "https://coverartarchive.org"
+    // MusicBrainz requires an identifying User-Agent with a contact (email or URL);
+    // see https://musicbrainz.org/doc/MusicBrainz_API/Rate_Limiting#User-Agent
     private val userAgent =
-        "${context.resources.getString(R.string.app_name)}/${context.getAppVersionName()} ( dev.dn0ne@gmail.com )"
+        "${context.resources.getString(R.string.app_name)}/${context.getAppVersionName()} ( https://github.com/Bjorn99/lotus )"
 
     override suspend fun searchMetadata(
         query: String,

--- a/app/src/main/java/com/dn0ne/player/app/domain/playlist/M3uExporter.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/playlist/M3uExporter.kt
@@ -1,0 +1,75 @@
+package com.dn0ne.player.app.domain.playlist
+
+import com.dn0ne.player.app.domain.track.Track
+import kotlin.math.roundToInt
+
+/**
+ * Serializes a list of tracks into Extended M3U8 (UTF-8) format.
+ *
+ * Spec reference: https://en.wikipedia.org/wiki/M3U#Extended_M3U
+ *
+ *   #EXTM3U
+ *   #EXTINF:<seconds>,<artist> - <title>
+ *   <absolute-file-path>
+ *
+ * We use absolute paths from [Track.data] rather than relative paths because
+ * Storage Access Framework abstracts away the final destination folder, so
+ * we have nowhere stable to make paths relative to. Absolute paths are also
+ * what other music players expect when the M3U is opened elsewhere.
+ *
+ * The formatter operates on a pure data [Entry] so it can be unit-tested
+ * without Android types (Track holds Uri / MediaItem which require a device).
+ */
+object M3uExporter {
+
+    private const val NEWLINE = "\n"
+    private const val HEADER = "#EXTM3U"
+
+    data class Entry(
+        val path: String,
+        val durationMillis: Int,
+        val title: String?,
+        val artist: String?,
+    )
+
+    fun export(tracks: List<Track>): String =
+        exportEntries(tracks.map { it.toEntry() })
+
+    fun exportEntries(entries: List<Entry>): String = buildString {
+        append(HEADER)
+        append(NEWLINE)
+        entries.forEach { entry ->
+            append("#EXTINF:")
+            append(entry.durationSeconds())
+            append(',')
+            append(entry.extinfLabel())
+            append(NEWLINE)
+            append(entry.path)
+            append(NEWLINE)
+        }
+    }
+
+    private fun Track.toEntry() = Entry(
+        path = data,
+        durationMillis = duration,
+        title = title,
+        artist = artist,
+    )
+
+    private fun Entry.durationSeconds(): Int {
+        // Duration is in milliseconds; EXTINF wants seconds, -1 if unknown.
+        if (durationMillis <= 0) return -1
+        return (durationMillis / 1000.0).roundToInt()
+    }
+
+    private fun Entry.extinfLabel(): String {
+        val cleanArtist = artist?.sanitise()?.takeIf { it.isNotBlank() }
+        val cleanTitle = title?.sanitise()?.takeIf { it.isNotBlank() }
+            ?: path.substringAfterLast('/').substringBeforeLast('.')
+        return if (cleanArtist != null) "$cleanArtist - $cleanTitle" else cleanTitle
+    }
+
+    // Sanitise so a single track's metadata can't break the multi-line format.
+    private fun String.sanitise(): String =
+        replace('\n', ' ').replace('\r', ' ').trim()
+}

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/M3uExport.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/M3uExport.kt
@@ -1,0 +1,77 @@
+package com.dn0ne.player.app.presentation.components.playlist
+
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import com.dn0ne.player.R
+import com.dn0ne.player.app.domain.playlist.M3uExporter
+import com.dn0ne.player.app.domain.track.Track
+
+/**
+ * Returns a trigger function for exporting a list of tracks to an M3U8 file.
+ *
+ * Usage:
+ *
+ *   val exportM3u = rememberM3uExport()
+ *   IconButton(onClick = { exportM3u(playlist.name ?: "playlist", playlist.trackList) }) { ... }
+ *
+ * The user picks the destination via Storage Access Framework
+ * ([ActivityResultContracts.CreateDocument] with `audio/x-mpegurl`).
+ *
+ * A cached list is kept between "launch picker" and "picker returned" because
+ * the system may recreate the activity during the flow; storing the intent in
+ * Compose state is simpler than threading it through Parcelables.
+ */
+private const val LOG_TAG = "M3uExport"
+
+@Composable
+fun rememberM3uExport(): (String, List<Track>) -> Unit {
+    val context = LocalContext.current
+    var pending by remember { mutableStateOf<List<Track>?>(null) }
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("audio/x-mpegurl")
+    ) { uri ->
+        val tracks = pending
+        pending = null
+        if (uri == null || tracks == null) return@rememberLauncherForActivityResult
+        val body = M3uExporter.export(tracks).toByteArray(Charsets.UTF_8)
+        try {
+            context.contentResolver.openOutputStream(uri)?.use { it.write(body) }
+                ?: error("openOutputStream returned null for $uri")
+            Toast.makeText(context, R.string.export_m3u_success, Toast.LENGTH_SHORT).show()
+        } catch (t: Throwable) {
+            // No point crashing: SAF can fail for a dozen reasons (removed SD
+            // card, revoked permission, read-only destination). Tell the user
+            // it didn't work so they can pick a different folder.
+            Log.w(LOG_TAG, "Failed to write M3U to $uri", t)
+            Toast.makeText(context, R.string.export_m3u_failure, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    return { suggestedName, tracks ->
+        pending = tracks
+        launcher.launch(sanitiseFilename(suggestedName) + ".m3u8")
+    }
+}
+
+// SAF accepts most characters but some file managers / filesystems choke on
+// the classics. Strip those, collapse runs of whitespace, cap the length.
+private fun sanitiseFilename(raw: String): String {
+    val cleaned = raw
+        .map { c -> if (c in INVALID_FILENAME_CHARS || c.isISOControl()) '_' else c }
+        .joinToString("")
+        .trim()
+        .ifEmpty { "playlist" }
+    return if (cleaned.length > MAX_NAME) cleaned.take(MAX_NAME) else cleaned
+}
+
+private val INVALID_FILENAME_CHARS = charArrayOf('/', '\\', ':', '*', '?', '"', '<', '>', '|')
+private const val MAX_NAME = 120

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/MutablePlaylist.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/MutablePlaylist.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.rounded.ArrowBackIosNew
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.DragHandle
+import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.FilterList
 import androidx.compose.material.icons.rounded.Search
@@ -222,6 +223,25 @@ fun MutablePlaylist(
                                         contentDescription = context.resources.getString(
                                             R.string.rename_playlist
                                         ) + " ${playlist.name}"
+                                    )
+                                }
+
+                                val exportM3u = rememberM3uExport()
+                                IconButton(
+                                    onClick = {
+                                        exportM3u(
+                                            playlist.name
+                                                ?: context.resources.getString(R.string.unknown),
+                                            playlist.trackList
+                                        )
+                                    },
+                                    enabled = playlist.trackList.isNotEmpty()
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Download,
+                                        contentDescription = context.resources.getString(
+                                            R.string.export_m3u
+                                        )
                                     )
                                 }
 

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/Playlist.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/Playlist.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.rounded.AddToQueue
 import androidx.compose.material.icons.rounded.ArrowBackIosNew
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.FilterList
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.SelectAll
@@ -169,19 +170,40 @@ fun Playlist(
                                 )
                             }
 
-                            IconButton(
-                                onClick = {
-                                    showSearchField = true
-                                }
-                            ) {
-                                Icon(
-                                    imageVector = if (replaceSearchWithFilter) {
-                                        Icons.Rounded.FilterList
-                                    } else Icons.Rounded.Search,
-                                    contentDescription = context.resources.getString(
-                                        R.string.track_search
+                            Row {
+                                val exportM3u = rememberM3uExport()
+                                IconButton(
+                                    onClick = {
+                                        exportM3u(
+                                            playlist.name
+                                                ?: context.resources.getString(R.string.unknown),
+                                            playlist.trackList
+                                        )
+                                    },
+                                    enabled = playlist.trackList.isNotEmpty()
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Download,
+                                        contentDescription = context.resources.getString(
+                                            R.string.export_m3u
+                                        )
                                     )
-                                )
+                                }
+
+                                IconButton(
+                                    onClick = {
+                                        showSearchField = true
+                                    }
+                                ) {
+                                    Icon(
+                                        imageVector = if (replaceSearchWithFilter) {
+                                            Icons.Rounded.FilterList
+                                        } else Icons.Rounded.Search,
+                                        contentDescription = context.resources.getString(
+                                            R.string.track_search
+                                        )
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -47,6 +47,9 @@
     <string name="search_library">Поиск по библиотеке</string>
     <string name="search_library_hint">Поиск треков, альбомов, исполнителей, жанров и плейлистов</string>
     <string name="search_no_results">Ничего не найдено</string>
+    <string name="export_m3u">Экспорт в M3U</string>
+    <string name="export_m3u_success">Плейлист экспортирован</string>
+    <string name="export_m3u_failure">Не удалось экспортировать плейлист</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -47,6 +47,9 @@
     <string name="search_library">Пошук у бібліотеці</string>
     <string name="search_library_hint">Пошук треків, альбомів, виконавців, жанрів і плейлистів</string>
     <string name="search_no_results">Нічого не знайдено</string>
+    <string name="export_m3u">Експорт у M3U</string>
+    <string name="export_m3u_success">Плейлист експортовано</string>
+    <string name="export_m3u_failure">Не вдалося експортувати плейлист</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,9 +8,9 @@
     <!-- Metadata provider link -->
     <string name="musicbrainz_uri" translatable="false">https://musicbrainz.org/</string>
     <!-- Repository link -->
-    <string name="repo_url" translatable="false">https://github.com/dn0ne/lotus</string>
-    <!-- Feedback mail link -->
-    <string name="feedback_url" translatable="false">mailto:dev.dn0ne@gmail.com</string>
+    <string name="repo_url" translatable="false">https://github.com/Bjorn99/lotus</string>
+    <!-- Feedback link (GitHub issue tracker) -->
+    <string name="feedback_url" translatable="false">https://github.com/Bjorn99/lotus/issues/new</string>
 
     <!-- Common back button -->
     <string name="back">Back</string>
@@ -59,6 +59,9 @@
     <string name="search_library">Search library</string>
     <string name="search_library_hint">Search tracks, albums, artists, genres, and playlists</string>
     <string name="search_no_results">No results</string>
+    <string name="export_m3u">Export to M3U</string>
+    <string name="export_m3u_success">Playlist exported</string>
+    <string name="export_m3u_failure">Couldn\'t export playlist</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Tracks</string>

--- a/app/src/test/java/com/dn0ne/player/app/domain/playlist/M3uExporterTest.kt
+++ b/app/src/test/java/com/dn0ne/player/app/domain/playlist/M3uExporterTest.kt
@@ -1,0 +1,154 @@
+package com.dn0ne.player.app.domain.playlist
+
+import com.dn0ne.player.app.domain.playlist.M3uExporter.Entry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class M3uExporterTest {
+
+    @Test
+    fun empty_playlist_still_has_header() {
+        val result = M3uExporter.exportEntries(emptyList())
+        assertEquals("#EXTM3U\n", result)
+    }
+
+    @Test
+    fun single_entry_renders_extinf_and_path() {
+        val result = M3uExporter.exportEntries(
+            listOf(
+                Entry(
+                    path = "/storage/emulated/0/Music/song.mp3",
+                    durationMillis = 184_000,
+                    title = "Hello",
+                    artist = "Adele",
+                )
+            )
+        )
+        val expected = buildString {
+            appendLine("#EXTM3U")
+            appendLine("#EXTINF:184,Adele - Hello")
+            appendLine("/storage/emulated/0/Music/song.mp3")
+        }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun missing_artist_falls_back_to_title_only() {
+        val result = M3uExporter.exportEntries(
+            listOf(
+                Entry(
+                    path = "/music/instrumental.flac",
+                    durationMillis = 60_000,
+                    title = "Reverie",
+                    artist = null,
+                )
+            )
+        )
+        assertTrue("expected label without dash, got:\n$result", result.contains("#EXTINF:60,Reverie\n"))
+    }
+
+    @Test
+    fun missing_title_falls_back_to_filename_without_extension() {
+        val result = M3uExporter.exportEntries(
+            listOf(
+                Entry(
+                    path = "/music/track 09.ogg",
+                    durationMillis = 0,
+                    title = null,
+                    artist = null,
+                )
+            )
+        )
+        // Duration is 0 (unknown) so we emit -1 per EXTM3U spec.
+        assertTrue(result.contains("#EXTINF:-1,track 09\n"))
+        assertTrue(result.contains("/music/track 09.ogg"))
+    }
+
+    @Test
+    fun blank_metadata_is_treated_like_missing() {
+        val result = M3uExporter.exportEntries(
+            listOf(
+                Entry(
+                    path = "/music/a.mp3",
+                    durationMillis = 1_000,
+                    title = "   ",
+                    artist = "",
+                )
+            )
+        )
+        // Both artist and title are blank; label falls back to filename.
+        assertTrue(result.contains("#EXTINF:1,a\n"))
+    }
+
+    @Test
+    fun newlines_in_metadata_do_not_break_format() {
+        val result = M3uExporter.exportEntries(
+            listOf(
+                Entry(
+                    path = "/m/x.mp3",
+                    durationMillis = 30_000,
+                    title = "Line1\nLine2",
+                    artist = "Bad\r\nArtist",
+                )
+            )
+        )
+        // Line count must match: header + extinf + path = 3 newlines terminating 3 lines.
+        assertEquals(3, result.count { it == '\n' })
+        assertTrue(result.contains("#EXTINF:30,Bad  Artist - Line1 Line2\n"))
+    }
+
+    @Test
+    fun duration_rounds_to_nearest_second() {
+        assertTrue(
+            M3uExporter.exportEntries(
+                listOf(Entry("/x.mp3", 1_499, "t", "a"))
+            ).contains("#EXTINF:1,")
+        )
+        assertTrue(
+            M3uExporter.exportEntries(
+                listOf(Entry("/x.mp3", 1_500, "t", "a"))
+            ).contains("#EXTINF:2,")
+        )
+    }
+
+    @Test
+    fun negative_duration_reports_unknown() {
+        val result = M3uExporter.exportEntries(
+            listOf(Entry("/x.mp3", -5, "t", "a"))
+        )
+        assertTrue(result.contains("#EXTINF:-1,"))
+    }
+
+    @Test
+    fun multiple_entries_are_written_in_order() {
+        val result = M3uExporter.exportEntries(
+            listOf(
+                Entry("/one.mp3", 1_000, "One", "A"),
+                Entry("/two.mp3", 2_000, "Two", "B"),
+                Entry("/three.mp3", 3_000, "Three", "C"),
+            )
+        )
+        val expected = buildString {
+            appendLine("#EXTM3U")
+            appendLine("#EXTINF:1,A - One")
+            appendLine("/one.mp3")
+            appendLine("#EXTINF:2,B - Two")
+            appendLine("/two.mp3")
+            appendLine("#EXTINF:3,C - Three")
+            appendLine("/three.mp3")
+        }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun output_uses_lf_not_crlf() {
+        val result = M3uExporter.exportEntries(
+            listOf(Entry("/x.mp3", 1_000, "t", "a"))
+        )
+        assertTrue(
+            "output should not contain CR — M3U readers expect LF-terminated lines",
+            !result.contains('\r')
+        )
+    }
+}


### PR DESCRIPTION
## What's in v1.2.2

Two things bundled into one PR: the next Phase 2 feature (**M3U playlist export**) and a **maintenance pass** to remove the upstream-pointing references this fork was still carrying. Once merged + tagged as `v1.2.2`, the release page will include global library search (PR #7) *and* everything below.

### Feature — export playlist to M3U

**Layman**: every playlist view now has a "Download" button that saves the playlist as a plain `.m3u8` file to any folder you pick. Open the file in VLC, PowerAmp, Foobar2000, Winamp, Musicolet — they'll all play the tracks in order. Works for user playlists and for any album / artist / genre view.

**Technical**:
- `M3uExporter` object, pure Kotlin (no Android deps), formats Extended M3U8: `#EXTM3U` header + `#EXTINF:<seconds>,<artist> - <title>` + absolute path per track
- Absolute paths from `Track.data` — SAF hides the destination folder, so relative paths have no anchor, and absolute paths are also what other players expect
- `rememberM3uExport()` composable helper wraps `ActivityResultContracts.CreateDocument("audio/x-mpegurl")`; writes via `ContentResolver.openOutputStream`; toast on success/failure
- Icon (`Icons.Rounded.Download`) added to top bar on `MutablePlaylist` and `Playlist` (album/artist/genre) screens; disabled when playlist is empty
- Unit-testable via `M3uExporter.Entry` (pure data, no Android types)
- **Tests** (`M3uExporterTest`): empty playlist, missing artist, missing title → filename fallback, blank metadata, newline/CR injection, LF-only output, duration rounding, `-1` when unknown, multi-entry ordering

### Maintenance — remove upstream-pointing references

| File | Before | After |
|---|---|---|
| `strings.xml` `repo_url` | `https://github.com/dn0ne/lotus` | `https://github.com/Bjorn99/lotus` |
| `strings.xml` `feedback_url` | `mailto:dev.dn0ne@gmail.com` | `https://github.com/Bjorn99/lotus/issues/new` |
| `MusicBrainzMetadataProvider.kt` UA | `( dev.dn0ne@gmail.com )` | `( https://github.com/Bjorn99/lotus )` |
| `LrclibLyricsProvider.kt` UA | `( dev.dn0ne@gmail.com )` | `( https://github.com/Bjorn99/lotus )` |
| `README.md` "Support" section | Fork-level donate ask | Credits upstream + links to their Liberapay; fork does not solicit donations |

Why it mattered: tapping "Feedback" in-app was opening a mail composer to the upstream author's inbox. The two User-Agent emails were also pointing API rate-limit / abuse complaints at them. MusicBrainz + LRCLIB both accept a URL as the contact string, so we're back inside spec.

### Version bump

- `versionCode 1_002_001 → 1_002_002`
- `versionName 1.2.1-community → 1.2.2-community`

### Housekeeping (done before opening this PR)

- `v1.2.1` tag + GitHub Release deleted (they pointed at `v1.2.0`'s commit because PR #7 hadn't merged when the tag was pushed). Next release goes straight from `v1.2.0` to `v1.2.2`.
- No other cleanup needed — no stale branches, no `.orig` files, the only remote branches are `master` and this feature branch.

## Test plan

- [ ] Open a user playlist → the new Download icon appears, is enabled when the playlist has tracks, disabled when empty
- [ ] Tap Download → Android file picker opens, suggests `<playlist-name>.m3u8`
- [ ] Save to Downloads → file appears, can be opened in VLC / Musicolet / another player and plays through
- [ ] Same flow works on an album / artist / genre view
- [ ] Open About page → "Repository" opens `Bjorn99/lotus`, "Feedback" opens GitHub issue tracker in a browser
- [ ] Try a MusicBrainz metadata search (track info → edit) → still returns results (User-Agent change is inside spec)
- [ ] Try fetching lyrics from LRCLIB → still returns results
- [ ] RU / UK locales show translated export labels
- [ ] After merging + tagging `v1.2.2`, the release page includes arm64-v8a / armeabi-v7a / x86 / x86_64 / universal APKs + `SHA256SUMS.txt`

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp