### PR TITLE
feat(playlists): smart playlists + CHANGELOG-driven release notes + tag/version preflight (v1.2.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,20 @@ name: Release
 
 # Builds and publishes a signed release whenever a version tag is pushed.
 # Example:
-#   git tag -a v1.2.0 -m "Lotus 1.2.0"
-#   git push origin v1.2.0
+#   git tag -a v1.2.3 -m "Lotus 1.2.3"
+#   git push origin v1.2.3
 #
 # Requires four repo secrets (Settings → Secrets and variables → Actions):
 #   LOTUS_KEYSTORE_BASE64   base64 of the release .jks file
-#                           (e.g. `base64 -w0 lotus-release.jks | pbcopy`)
+#                           (e.g. `base64 -w0 lotus-release.jks`)
 #   LOTUS_KEYSTORE_PASSWORD keystore password
 #   LOTUS_KEY_ALIAS         key alias inside the keystore
 #   LOTUS_KEY_PASSWORD      password for that key
+#
+# Release notes are sourced from CHANGELOG.md. The tag name (v1.2.3) must
+# match the committed versionName (1.2.3-community), and CHANGELOG.md must
+# have a matching `## 1.2.3 — ...` section, or the workflow fails before
+# building anything. Keeps tags, APKs, and changelog in lockstep.
 
 on:
   push:
@@ -75,6 +80,65 @@ jobs:
             exit 1
           fi
 
+      # Prevent the "tag pushed before the version bump merged" failure mode
+      # that shipped two mislabelled releases already. versionName looks like
+      # "1.2.3-community"; tag looks like "v1.2.3". They must agree.
+      - name: Check tag matches committed versionName
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${TAG#v}"
+          BUILD_VERSION=$(
+            grep 'versionName = ' app/build.gradle.kts \
+              | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+).*/\1/' \
+              | head -n1
+          )
+          if [ "$TAG_VERSION" != "$BUILD_VERSION" ]; then
+            echo "::error::Tag ($TAG, -> $TAG_VERSION) does not match versionName in app/build.gradle.kts ($BUILD_VERSION). Fix the tag or bump the version, then re-tag."
+            exit 1
+          fi
+          echo "Tag $TAG ↔ versionName $BUILD_VERSION — OK."
+
+      # CHANGELOG.md section for this tag is the body of the GitHub Release.
+      # Fails if the section is missing so we never ship a release with
+      # empty / default notes.
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+
+          # Standard fork-summary preamble on every release.
+          cat > "$NOTES_FILE" <<'EOF'
+          > **Community fork of [Lotus](https://github.com/dn0ne/lotus).** See the [README](https://github.com/Bjorn99/lotus/blob/master/README.md#what-this-fork-adds-vs-upstream-dn0nelotus) for the cumulative list of improvements this fork carries over the upstream.
+          >
+          > **Which APK do I pick?** If you're not sure, download `lotus-*-universal-release.apk` — it works on any phone. Otherwise pick the one matching your CPU architecture (`arm64-v8a` covers most modern phones). Verify the download against `SHA256SUMS.txt`.
+
+          EOF
+
+          # Extract "## <VERSION>" through the next "## " header.
+          awk -v ver="$VERSION" '
+              /^## / {
+                  if (in_section) exit
+                  if ($2 == ver) { in_section = 1 }
+              }
+              in_section { print }
+          ' CHANGELOG.md >> "$NOTES_FILE"
+
+          # Sanity-check that the extraction found something.
+          if ! grep -q "^## ${VERSION}" "$NOTES_FILE"; then
+            echo "::error::CHANGELOG.md has no '## ${VERSION}' section. Add one before tagging."
+            exit 1
+          fi
+
+          echo "::group::Release notes body"
+          cat "$NOTES_FILE"
+          echo "::endgroup::"
+          echo "NOTES_FILE=$NOTES_FILE" >> "$GITHUB_ENV"
+
       - name: Unit tests
         run: ./gradlew testDebugUnitTest --stacktrace
 
@@ -124,13 +188,16 @@ jobs:
           set -euo pipefail
           cd app/build/outputs/apk/release
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Release $TAG already exists — re-uploading assets."
+            echo "Release $TAG already exists — re-uploading assets and refreshing notes."
+            gh release edit "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --notes-file "$NOTES_FILE"
             gh release upload "$TAG" *.apk SHA256SUMS.txt \
               --repo "$GITHUB_REPOSITORY" --clobber
           else
             gh release create "$TAG" \
               --title "$TAG" \
-              --generate-notes \
+              --notes-file "$NOTES_FILE" \
               --repo "$GITHUB_REPOSITORY" \
               *.apk SHA256SUMS.txt
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,125 @@
+# Changelog
+
+All notable changes to Lotus (community fork) are recorded in this file,
+newest first. For the full picture of how this fork diverges from upstream
+`dn0ne/lotus`, see the **"What this fork adds"** section in
+[README.md](README.md).
+
+Each release page on GitHub is built from the matching section below, so
+the wording is deliberately aimed at the end user.
+
+## 1.2.3 — Smart playlists + release notes overhaul
+
+**Layman:** The Playlists tab now has a "Smart" section at the top with
+two auto-filled lists — **Recently added** (files added to your library
+in the last 30 days) and **Random mix** (up to 100 tracks shuffled).
+They behave like any other playlist: tap to play, export to M3U, etc.
+Release pages on GitHub now include a human-readable description of
+what's in the release plus a summary of how this fork differs from
+upstream — no more "click through and guess what changed."
+
+**Technical:**
+- `SmartPlaylists` domain object — pure Kotlin builders for `recentlyAdded`
+  (`dateModified > now - 30d`, capped at 100, sorted desc) and `randomMix`
+  (seeded shuffle, capped at 100). Derived in `PlayerScreen` composable
+  layer so the localised names come from `stringResource` without forcing
+  `Context` into the `PlayerViewModel` constructor.
+- `Tab.Playlists` branch now renders a two-section layout: Smart (header
+  + cards/rows, hidden when empty or in selection mode) then user
+  playlists. `GridItemSpan(maxLineSpan)` lets the section headers span
+  the full grid width.
+- Smart-list taps route through `onAlbumPlaylistSelection` → immutable
+  `PlayerRoutes.Playlist` view (can't be renamed or reordered). Long-press
+  is a no-op — smart lists aren't part of bulk selection.
+- `.github/workflows/release.yml` now extracts the matching section from
+  `CHANGELOG.md` and uses it as the GitHub Release body instead of
+  `--generate-notes`. Each release page also gets a stable fork-summary
+  preamble.
+- Release workflow gains a preflight step that fails fast when the tag
+  name (`v1.2.3`) does not match the committed `versionName`
+  (`1.2.3-community`). Prevents the "tag pushed before version bump
+  merged" mis-release mode we hit twice.
+
+## 1.2.2 — Export to M3U + global library search + maintenance
+
+**Layman:** Two new features. Every playlist view has a new Download
+icon that saves the playlist as a standard `.m3u8` file to any folder
+you pick — playable in VLC, Musicolet, PowerAmp, Foobar2000, and
+almost every other music app. A new magnifying-globe icon in the top
+bar opens one search box that looks through everything at once: tracks,
+albums, artists, genres, and playlists. Also fixed: the About page's
+Repository and Feedback buttons now open *this* fork's links (they
+previously pointed at the upstream author's repo and personal email,
+so tapping "Feedback" was emailing a stranger).
+
+**Technical:**
+- **M3U export** — `M3uExporter` domain object, pure Kotlin formatter for
+  Extended M3U8 (UTF-8): `#EXTM3U` header + `#EXTINF:<seconds>,<artist>
+  - <title>` + absolute path per track. Covered by 9 JVM unit tests.
+  `rememberM3uExport()` composable wraps
+  `ActivityResultContracts.CreateDocument("audio/x-mpegurl")`; writes via
+  `ContentResolver.openOutputStream`; success/failure toast. Uses
+  absolute paths (`Track.data`) because SAF hides the destination folder.
+  Download icon added on top bar of both `MutablePlaylist` (user
+  playlists) and `Playlist` (album/artist/genre) views; disabled when
+  the playlist is empty.
+- **Global library search** — `GlobalSearchSheet`: full-screen `Dialog`,
+  single `SearchField`, five grouped result sections (tracks top-8,
+  playlists / albums / artists / genres top-5 each). Empty sections
+  collapse; blank/no-match states render distinct hints. Reuses existing
+  `filterTracks` / `filterPlaylists` helpers — no ViewModel or
+  event-channel changes. Navigation dispatches the existing
+  `onPlaylistSelection` / `onAlbumPlaylistSelection` callbacks. Query
+  state local to the sheet; dropped on dismiss.
+- **Upstream references removed from the in-app UI:**
+  - `repo_url` → `https://github.com/Bjorn99/lotus`
+    (was `dn0ne/lotus`)
+  - `feedback_url` → `https://github.com/Bjorn99/lotus/issues/new`
+    (was `mailto:dev.dn0ne@gmail.com`)
+  - MusicBrainz + LRCLIB `User-Agent` contact → fork repo URL
+    (URL form is spec-compliant; rate-limit / abuse reports now route
+    to this fork)
+- README `## Support` section rewritten to credit the upstream author
+  and link to their Liberapay; this fork does not solicit donations.
+
+## 1.2.0 — First community release
+
+**Layman:** The foundational release. Everything needed to keep the
+app stable and maintainable going forward. The app no longer crashes
+silently when lyrics reading hits a weird file, and if something does
+go wrong, crashes are saved to a log file you can share. The
+underlying database was modernised. You can share any track directly
+to other apps. The release itself is signed and published through an
+automated pipeline.
+
+**Technical:**
+- **Realm → Room migration** with one-shot `RealmToRoomMigrator`
+  (legacy store read once on first launch; Realm + Room DAOs run
+  side-by-side for one release so the legacy store can be removed in
+  a later pass).
+- **Crash reporter** (`CrashReporter`) writes uncaught-exception stack
+  traces to private app files, exposed via `FileProvider` authority
+  `${applicationId}.crashlogs` for share-sheet delivery. No network,
+  no analytics, no telemetry.
+- **`LyricsReaderImpl` hardened:** `jaudiotagger` exceptions are caught
+  and logged (wide-net `Throwable` — jaudiotagger throws many checked
+  types); the temp file is cleaned up in `finally`; no longer nukes
+  the shared cache directory (Coil's image cache lives there).
+- **CI pipeline** (`.github/workflows/ci.yml`): JDK 17, unit tests,
+  `assembleDebug` / `assembleRelease` / `lintRelease`, detekt + ktlint;
+  artifact uploads for APKs + reports; diagnostic dump on failure.
+- Lint / detekt / ktlint all in "report-only" mode (`abortOnError =
+  false` / `ignoreFailures = true`) so legacy findings don't block CI;
+  findings surface via the uploaded HTML reports.
+- **Release signing pipeline**
+  (`.github/workflows/release.yml`): triggers on `v*` tag push, decodes
+  keystore from `LOTUS_KEYSTORE_BASE64`, runs `assembleRelease`,
+  verifies with `apksigner`, publishes per-ABI + universal APKs and
+  `SHA256SUMS.txt` to a GitHub Release.
+- **Share track** — `ACTION_SEND` intent with MediaStore content URI,
+  MIME from `ContentResolver.getType()` (`audio/*` fallback), title as
+  `EXTRA_SUBJECT`, `FLAG_GRANT_READ_URI_PERMISSION`; dropdown entry in
+  `TrackMenu` wired from `TrackListItem` + both `PlayerSheet` call sites.
+- README retargeted from upstream `dn0ne/lotus` to this fork's releases.
+- **Fork rebrand**: `applicationId = com.dn0ne.lotus.community` so the
+  community build coexists with the original on the same device.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,77 @@ an issue — we'll respect your wishes.
 - Manually update track details or fetch accurate info from [MusicBrainz](https://musicbrainz.org/)
 - Designed with [Material You](https://m3.material.io/) and supports dynamic color palettes
 
+## What this fork adds (vs upstream dn0ne/lotus)
+
+Each item appears in the order it was introduced. Per-version notes live
+in [CHANGELOG.md](CHANGELOG.md); summaries below are cumulative.
+
+### Stability and infrastructure
+
+- **Continuous Integration pipeline** — every pull request runs unit tests,
+  builds debug + release APKs, runs Android lint + detekt + ktlint, and
+  uploads reports as artifacts. Broken code never reaches master.
+- **Signed release pipeline** — pushing a `v*` tag triggers a GitHub
+  Actions workflow that builds per-ABI + universal APKs, signs them with
+  the release keystore, verifies with `apksigner`, generates
+  `SHA256SUMS.txt`, and publishes everything to a GitHub Release.
+- **Realm → Room database migration** — the upstream app stored playlists
+  and lyrics in Realm (an embedded mobile database that had been
+  deprecated). Lotus migrates to Android's official [Room](https://developer.android.com/training/data-storage/room)
+  on first launch via a one-shot `RealmToRoomMigrator`, then keeps both
+  side-by-side for one release so the legacy store can be safely removed
+  in a later cleanup pass.
+- **Crash reporter** — uncaught exceptions are written to a private log
+  file instead of just killing the process. From the About page you can
+  share the most recent crash log via the Android share sheet, which
+  makes "it crashed for me" bug reports actually actionable. No network,
+  no analytics, no telemetry.
+- **Lyrics reader hardening** — the upstream reader could crash on
+  malformed files and also nuked the shared cache directory (which Coil
+  uses for album-art thumbnails) on every read. Lotus catches the
+  jaudiotagger exceptions, deletes only its own temp file, and logs
+  rather than crashing. Fewer crashes, no more surprise re-downloaded
+  artwork.
+- **Release-build lint posture flipped** — Android lint and the two
+  Kotlin analysers (detekt + ktlint) run on every PR in "report-only"
+  mode. Findings surface as downloadable HTML reports without gating the
+  build, so the backlog can be burned down deliberately.
+
+### Features
+
+- **Share track** — the track-dropdown menu has a "Share" entry that
+  sends the current track to any app via Android's share sheet (audio
+  file + title subject line). Works from the track list and from the
+  now-playing sheet.
+- **Global library search** — a magnifying-globe icon in the top bar
+  opens a single search field that queries across tracks, albums,
+  artists, genres, and playlists at once. Results are grouped by
+  category; tap anything to jump to it. The existing per-tab search
+  still works unchanged.
+- **Export playlist to M3U** — a Download icon on every playlist view
+  (user playlists plus album/artist/genre views) writes the playlist as
+  a standard `.m3u8` file to a folder you pick. Open the file in VLC,
+  PowerAmp, Musicolet, Foobar2000, or anywhere else M3U is supported.
+- **Smart playlists** — the Playlists tab now shows auto-generated
+  lists at the top: **Recently added** (files modified within the last
+  30 days) and **Random mix** (up to 100 tracks shuffled). They feel
+  like any other playlist — tap to open, play from, or export to M3U.
+
+### Housekeeping
+
+- **Fork rebrand** — `applicationId` is `com.dn0ne.lotus.community`, so
+  the community build coexists with the original upstream build side-by-side
+  on the same device.
+- **In-app links point at the right place** — Repository / Feedback
+  buttons open this fork's GitHub repo and issue tracker, not the
+  upstream author's personal email.
+- **MusicBrainz / LRCLIB contact** — the User-Agent sent with those
+  API calls identifies this fork, so rate-limit or abuse reports reach
+  us rather than the upstream author.
+- **Zero telemetry, zero analytics, phone-only** — no network calls
+  except LRCLIB (lyrics on demand) and MusicBrainz (optional metadata
+  search). No crash reporting SDKs, no analytics, no server.
+
 ## Download
 
 Community builds of this fork are published as signed APKs on the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_002_002
-        versionName = "1.2.2-community"
+        versionCode = 1_002_003
+        versionName = "1.2.3-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/domain/playlist/SmartPlaylists.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/playlist/SmartPlaylists.kt
@@ -1,0 +1,54 @@
+package com.dn0ne.player.app.domain.playlist
+
+import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.domain.track.Track
+import kotlin.random.Random
+
+/**
+ * Builders for synthetic "smart" playlists computed from the track library.
+ *
+ * Unlike album/artist/genre groupings, smart playlists don't correspond to a
+ * tag field — they're rule-based views ("recently added", "random mix").
+ *
+ * Kept in the `domain` layer as pure functions so unit tests can exercise
+ * them without touching Android types or resources. The UI layer is
+ * responsible for the localised name — callers pass the already-resolved
+ * strings in.
+ */
+object SmartPlaylists {
+
+    // Window for "Recently Added", in seconds. Track.dateModified is epoch
+    // seconds (MediaStore convention — see TrackInfoSheet's *1000 conversion).
+    private const val RECENTLY_ADDED_WINDOW_SECONDS: Long = 30L * 24L * 60L * 60L
+
+    // Cap the synthetic lists so the UI stays snappy even on large libraries.
+    private const val MAX_ENTRIES = 100
+
+    fun recentlyAdded(
+        tracks: List<Track>,
+        name: String,
+        nowSeconds: Long = System.currentTimeMillis() / 1000L,
+    ): Playlist? {
+        val cutoff = nowSeconds - RECENTLY_ADDED_WINDOW_SECONDS
+        val picked = tracks
+            .asSequence()
+            .filter { it.dateModified > cutoff }
+            .sortedByDescending { it.dateModified }
+            .take(MAX_ENTRIES)
+            .toList()
+        return if (picked.isEmpty()) null else Playlist(name = name, trackList = picked)
+    }
+
+    fun randomMix(
+        tracks: List<Track>,
+        name: String,
+        seed: Long = Random.Default.nextLong(),
+    ): Playlist? {
+        if (tracks.isEmpty()) return null
+        // Seeded so a given (tracks, seed) is deterministic — callers that
+        // want a stable order across recompositions can pass a cached seed;
+        // callers that want a fresh shuffle each tap pass a new one.
+        val picked = tracks.shuffled(Random(seed)).take(MAX_ENTRIES)
+        return Playlist(name = name, trackList = picked)
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -73,6 +74,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
@@ -84,6 +86,7 @@ import com.dn0ne.player.R
 import com.dn0ne.player.app.domain.sort.PlaylistSort
 import com.dn0ne.player.app.domain.sort.SortOrder
 import com.dn0ne.player.app.domain.sort.TrackSort
+import com.dn0ne.player.app.domain.playlist.SmartPlaylists
 import com.dn0ne.player.app.domain.track.Playlist
 import com.dn0ne.player.app.domain.track.Track
 import com.dn0ne.player.app.domain.track.filterPlaylists
@@ -94,6 +97,7 @@ import com.dn0ne.player.app.presentation.components.TrackSortButton
 import com.dn0ne.player.app.presentation.components.playback.PlayerSheet
 import com.dn0ne.player.app.presentation.components.playlist.AddToOrCreatePlaylistBottomSheet
 import com.dn0ne.player.app.presentation.components.playlist.DeletePlaylistDialog
+import com.dn0ne.player.app.presentation.components.playlist.PlaylistSectionHeader
 import com.dn0ne.player.app.presentation.components.playlist.MutablePlaylist
 import com.dn0ne.player.app.presentation.components.playlist.Playlist
 import com.dn0ne.player.app.presentation.components.playlist.RenamePlaylistBottomSheet
@@ -282,6 +286,28 @@ fun PlayerScreen(
                         val genrePlaylists by viewModel.genrePlaylists.collectAsState()
                         val folderPlaylists by viewModel.folderPlaylists.collectAsState()
 
+                        // Smart playlists are derived here (not in the VM)
+                        // so the localised names come from the Compose
+                        // resource lookup without forcing a Context into
+                        // PlayerViewModel's constructor. Recomputed only
+                        // when trackList changes — "Random Mix" stays
+                        // stable within a session.
+                        val recentlyAddedName = stringResource(R.string.smart_recently_added)
+                        val randomMixName = stringResource(R.string.smart_random_mix)
+                        val smartPlaylists = remember(
+                            trackList, recentlyAddedName, randomMixName
+                        ) {
+                            val seed = System.currentTimeMillis()
+                            buildList {
+                                SmartPlaylists
+                                    .recentlyAdded(trackList, recentlyAddedName)
+                                    ?.let(::add)
+                                SmartPlaylists
+                                    .randomMix(trackList, randomMixName, seed)
+                                    ?.let(::add)
+                            }
+                        }
+
                         val gridState = rememberLazyGridState()
                         val gridPlaylists by viewModel.settings.gridPlaylists.collectAsState()
 
@@ -371,6 +397,7 @@ fun PlayerScreen(
                                 navController.navigate(PlayerRoutes.Playlist)
                             },
                             playlists = playlists,
+                            smartPlaylists = smartPlaylists,
                             albumPlaylists = albumPlaylists,
                             artistPlaylists = artistPlaylists,
                             genrePlaylists = genrePlaylists,
@@ -945,6 +972,7 @@ fun MainPlayerScreen(
     onGoToAlbumClick: (Track) -> Unit,
     onGoToArtistClick: (Track) -> Unit,
     playlists: List<Playlist>,
+    smartPlaylists: List<Playlist>,
     albumPlaylists: List<Playlist>,
     artistPlaylists: List<Playlist>,
     genrePlaylists: List<Playlist>,
@@ -1343,8 +1371,33 @@ fun MainPlayerScreen(
             }
 
             Tab.Playlists -> {
+                val filteredSmart = smartPlaylists.filterPlaylists(searchFieldValue)
                 if (gridPlaylists) {
                     if (!isInSelectionMode) {
+                        if (filteredSmart.isNotEmpty()) {
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                PlaylistSectionHeader(
+                                    text = context.resources.getString(R.string.smart_playlists)
+                                )
+                            }
+                            playlistCards(
+                                playlists = filteredSmart,
+                                sort = playlistSort,
+                                sortOrder = playlistSortOrder,
+                                fallbackPlaylistTitle = context.resources.getString(R.string.unknown),
+                                showSinglePreview = false,
+                                // Smart playlists navigate to the immutable view
+                                // (same as album/artist/genre) — they can't be
+                                // renamed or reordered.
+                                onCardClick = onAlbumPlaylistSelection,
+                                onLongClick = { /* smart lists aren't selectable */ }
+                            )
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                PlaylistSectionHeader(
+                                    text = context.resources.getString(R.string.playlists)
+                                )
+                            }
+                        }
                         playlistCards(
                             playlists = playlists.filterPlaylists(searchFieldValue),
                             sort = playlistSort,
@@ -1378,6 +1431,27 @@ fun MainPlayerScreen(
                     }
                 } else {
                     if (!isInSelectionMode) {
+                        if (filteredSmart.isNotEmpty()) {
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                PlaylistSectionHeader(
+                                    text = context.resources.getString(R.string.smart_playlists)
+                                )
+                            }
+                            playlistRows(
+                                playlists = filteredSmart,
+                                sort = playlistSort,
+                                sortOrder = playlistSortOrder,
+                                fallbackPlaylistTitle = context.resources.getString(R.string.unknown),
+                                showSinglePreview = false,
+                                onRowClick = onAlbumPlaylistSelection,
+                                onLongClick = { /* smart lists aren't selectable */ }
+                            )
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                PlaylistSectionHeader(
+                                    text = context.resources.getString(R.string.playlists)
+                                )
+                            }
+                        }
                         playlistRows(
                             playlists = playlists.filterPlaylists(searchFieldValue),
                             sort = playlistSort,

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/PlaylistSectionHeader.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/PlaylistSectionHeader.kt
@@ -1,0 +1,24 @@
+package com.dn0ne.player.app.presentation.components.playlist
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+// Used to separate smart playlists from user playlists inside the Playlists
+// tab's lazy grid. Spans all columns via its caller's `GridItemSpan` setup.
+@Composable
+fun PlaylistSectionHeader(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp, bottom = 4.dp, start = 4.dp, end = 4.dp),
+    )
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -51,6 +51,11 @@
     <string name="export_m3u_success">Плейлист экспортирован</string>
     <string name="export_m3u_failure">Не удалось экспортировать плейлист</string>
 
+    <!-- Smart playlists -->
+    <string name="smart_playlists">Автоплейлисты</string>
+    <string name="smart_recently_added">Недавно добавленные</string>
+    <string name="smart_random_mix">Случайная подборка</string>
+
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>
     <string name="albums">Альбомы</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -51,6 +51,11 @@
     <string name="export_m3u_success">Плейлист експортовано</string>
     <string name="export_m3u_failure">Не вдалося експортувати плейлист</string>
 
+    <!-- Smart playlists -->
+    <string name="smart_playlists">Автоплейлисти</string>
+    <string name="smart_recently_added">Нещодавно додані</string>
+    <string name="smart_random_mix">Випадкова добірка</string>
+
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>
     <string name="albums">Альбоми</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,11 @@
     <string name="export_m3u_success">Playlist exported</string>
     <string name="export_m3u_failure">Couldn\'t export playlist</string>
 
+    <!-- Smart playlists -->
+    <string name="smart_playlists">Smart</string>
+    <string name="smart_recently_added">Recently added</string>
+    <string name="smart_random_mix">Random mix</string>
+
     <!-- Tabs' names -->
     <string name="tracks">Tracks</string>
     <string name="albums">Albums</string>


### PR DESCRIPTION
## What's in v1.2.3

Last Phase 2 feature (**Smart playlists**) plus a meta upgrade: from now on, every release page tells the reader what's actually in it — the fork's cumulative improvements and that specific version's highlights — in both layman and technical terms.

---

### Feature — Smart playlists

**Layman:** The Playlists tab now has a "Smart" section at the top with two auto-generated lists: **Recently added** (files added to your library in the last 30 days) and **Random mix** (up to 100 tracks shuffled). Tap them like any other playlist. Export to M3U works on them too.

**Technical:**
- `SmartPlaylists` domain object — pure-Kotlin builders for `recentlyAdded` (`dateModified > now - 30d`, sorted desc, capped at 100) and `randomMix` (seeded shuffle, capped at 100).
- Derivation lives in the PlayerScreen composable (`remember(trackList, names...)`), not the ViewModel — so localised names come from `stringResource` without forcing `Context` into `PlayerViewModel`'s constructor.
- `Tab.Playlists` branch refactored: Smart header + smart list cards/rows (hidden when empty or in selection mode), then user-playlist header + the existing grid. Section headers use `GridItemSpan(maxLineSpan)` so they span the full grid width.
- Smart-list taps route via `onAlbumPlaylistSelection` → immutable `PlayerRoutes.Playlist` view (smart lists aren't renamable or reorderable). Long-press is a no-op — bulk-selection is for user playlists only.

### Release pipeline — human-readable notes on every release

- `release.yml` no longer uses `--generate-notes`.
- New step extracts the `## X.Y.Z` section from `CHANGELOG.md` via awk (`$2 == ver`), stops at the next `## ` header, prepends a stable fork-summary preamble (link to README "vs upstream" + "which APK do I pick?" guidance), and passes the combined file to `gh release create --notes-file`.
- For re-tags / workflow-dispatch runs, `gh release edit --notes-file` refreshes the body on the existing release.
- Fails fast if `CHANGELOG.md` has no matching section for the tag.

### Release pipeline — prevent mislabelled releases

- New preflight step fails the job if the pushed tag name (`v1.2.3`) doesn't match the committed `versionName` (`1.2.3-community`).
- Closes the failure mode we hit twice where a tag was pushed before a version-bump PR was merged, producing "vX.Y.Z" APKs that were actually versionName X.Y.(Z-1)-community.

### Docs — "What this fork adds (vs upstream)"

- New authoritative section in `README.md` listing every cumulative fork improvement (CI + signed release pipeline, Realm→Room migration, crash reporter, lyrics reader hardening, share track, global library search, M3U export, smart playlists, fork rebrand, upstream-pointer cleanup). Layman explanation per item.
- New `CHANGELOG.md` at repo root with sections for 1.2.0 / 1.2.2 / 1.2.3, each with "Layman" and "Technical" blurbs. Drives the release notes.

### Version

- `versionCode 1_002_002 → 1_002_003`
- `versionName 1.2.2-community → 1.2.3-community`

---

## Test plan

- [ ] Open the Playlists tab on a device with at least some recent files → "Smart" section appears at top with "Recently added" and "Random mix"
- [ ] Tap "Recently added" → opens the immutable playlist view, correct tracks listed
- [ ] Tap "Random mix" → opens the immutable playlist view, 100 tracks (or fewer if library is smaller), randomised
- [ ] Long-press a smart list → nothing happens (no selection mode activation)
- [ ] Long-press a user playlist → selection mode activates; smart section disappears while in selection mode
- [ ] Use the per-tab search on Playlists → smart lists are filtered by name too
- [ ] Device with no music (clean install, empty library) → Smart section hidden, no empty placeholder
- [ ] Export a smart playlist to M3U → works, playable in VLC
- [ ] RU / UK locales show translated smart-list names + section header
- [ ] After merging + tagging `v1.2.3`, the release page body includes the fork-summary preamble, the v1.2.3 CHANGELOG section, and all five APK flavours + `SHA256SUMS.txt`
- [ ] Sanity-test the version preflight: temporarily push a tag that doesn't match `versionName` → workflow fails at "Check tag matches committed versionName" before building anything

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp