### PR TITLE
refactor(stability): remove all !! force-unwraps — Phase 3 #2 (v1.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.3.1 — Stability: remove force-unwraps from playback UI
+
+**Layman:** Pure stability fix, no visible changes. The player sheet
+and track-info screens used to assume there was always a current track
+when they were drawn. Most of the time that's true, but during certain
+state transitions (clearing the queue, stopping playback, app coming
+back from background) the assumption could briefly fail and crash the
+app. The screens now skip drawing for that one frame instead.
+
+**Technical:**
+- Phase 3 cleanup, item 2 of 4. Replaces every `!!` non-null assertion
+  in `app/src/main/java/com/dn0ne/player/` (six sites total) with a
+  null-safe pattern. Zero `!!` operators remain in main sources.
+- `BottomPlayer`, `ExpandedPlayer` (two inner scopes), and
+  `PlaybackControl` in `PlayerSheet.kt`: each `derivedStateOf {
+  playbackState.currentTrack!! }` is split into a nullable
+  `derivedStateOf { playbackState.currentTrack }` plus an explicit
+  `?: return@<scope>` guard. The remaining body still uses a non-null
+  `currentTrack` (via local shadow), so no downstream call sites
+  changed.
+- `TrackInfoSheet.kt` `Changes` and `ManualEditing` child routes: the
+  `state.track!!` arg is replaced with `val track = state.track ?:
+  return@composable` followed by `track = track`. If the navigation
+  child renders before its parent populated the track (a state race),
+  the route no-ops instead of NPE-ing.
+- The parent `PlayerScreen` already gates the entire player sheet via
+  `AnimatedVisibility(visible = currentTrack != null, …)`, but
+  `AnimatedVisibility` keeps composing the child for the duration of
+  the exit animation — that's the gap these guards close.
+
 ## 1.3.0 — Drop Realm, Room-only storage
 
 **Layman:** A long-overdue cleanup with no visible behaviour change on

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_003_000
-        versionName = "1.3.0-community"
+        versionCode = 1_003_001
+        versionName = "1.3.1-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/PlayerSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/PlayerSheet.kt
@@ -336,11 +336,14 @@ fun BottomPlayer(
             }
     ) {
         val playbackState by playbackStateFlow.collectAsState()
-        val currentTrack by remember {
-            derivedStateOf {
-                playbackState.currentTrack!!
-            }
+        // The parent (`PlayerScreen.kt`) wraps us in
+        // `AnimatedVisibility(visible = currentTrack != null, …)`, but the
+        // exit animation keeps composing us briefly after `currentTrack`
+        // flips to null. Guard explicitly so a state race can't NPE.
+        val currentTrackOrNull: Track? by remember {
+            derivedStateOf { playbackState.currentTrack }
         }
+        val currentTrack = currentTrackOrNull ?: return@Box
         val isPlaying by remember {
             derivedStateOf {
                 playbackState.isPlaying
@@ -629,11 +632,10 @@ fun ExpandedPlayer(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
                 ) {
-                    val currentTrack by remember {
-                        derivedStateOf {
-                            playbackState.currentTrack!!
-                        }
+                    val currentTrackOrNull: Track? by remember {
+                        derivedStateOf { playbackState.currentTrack }
                     }
+                    val currentTrack = currentTrackOrNull ?: return@Column
 
                     AnimatedContent(
                         targetState = currentTrack,
@@ -704,11 +706,10 @@ fun ExpandedPlayer(
                     horizontalArrangement = Arrangement.Center
                 ) {
 
-                    val currentTrack by remember {
-                        derivedStateOf {
-                            playbackState.currentTrack!!
-                        }
+                    val currentTrackOrNull: Track? by remember {
+                        derivedStateOf { playbackState.currentTrack }
                     }
+                    val currentTrack = currentTrackOrNull ?: return@Row
                     AnimatedContent(
                         targetState = currentTrack,
                         label = "cover-art-animation"
@@ -966,11 +967,10 @@ fun PlaybackControl(
                 playbackState.position
             }
         }
-        val currentTrack by remember {
-            derivedStateOf {
-                playbackState.currentTrack!!
-            }
+        val currentTrackOrNull: Track? by remember {
+            derivedStateOf { playbackState.currentTrack }
         }
+        val currentTrack = currentTrackOrNull ?: return@Column
         val isPlaying by remember {
             derivedStateOf {
                 playbackState.isPlaying

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/trackinfo/TrackInfoSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/trackinfo/TrackInfoSheet.kt
@@ -329,8 +329,14 @@ fun TrackInfoSheet(
                     )
                 }
                 composable<TrackInfoRoutes.Changes> {
+                    // state.track is set when entering the TrackInfoSheet
+                    // (it's the track the user picked "Track info" on). If
+                    // it's somehow null when this child route renders, no-op
+                    // rather than crash — the user will just see an empty
+                    // sheet and can back out.
+                    val track = state.track ?: return@composable
                     ChangesSheet(
-                        track = state.track!!,
+                        track = track,
                         state = state.changesSheetState,
                         onBackClick = {
                             navController.navigateUp()
@@ -347,8 +353,9 @@ fun TrackInfoSheet(
                 }
 
                 composable<TrackInfoRoutes.ManualEditing> {
+                    val track = state.track ?: return@composable
                     ManualInfoEditSheet(
-                        track = state.track!!,
+                        track = track,
                         state = state.manualInfoEditSheetState,
                         isCoverArtEditable = state.isCoverArtEditable,
                         onPickCoverArtClick = onPickCoverArtClick,


### PR DESCRIPTION
## What's in v1.3.1

Phase 3 cleanup, **item 2 of 4** — null-safety pass.

**Layman:** Pure stability fix, no visible changes. The player sheet and track-info screens used to assume there was always a current track when they were drawn. Most of the time that's true, but during certain state transitions (clearing the queue, stopping playback, app coming back from background) the assumption could briefly fail and crash the app. The screens now skip drawing for that one frame instead.

**Technical:**

### What's gone
Every `!!` non-null assertion in `app/src/main/java/com/dn0ne/player/`. Six sites total. `grep -rn '!!' app/src/main/java/com/dn0ne/player --include='*.kt'` now returns empty.

### PlayerSheet.kt — four sites
All four were the same pattern:

```kotlin
val currentTrack by remember {
    derivedStateOf { playbackState.currentTrack!! }
}
```

Replaced with:

```kotlin
val currentTrackOrNull: Track? by remember {
    derivedStateOf { playbackState.currentTrack }
}
val currentTrack = currentTrackOrNull ?: return@<scope>
```

The downstream body still binds `currentTrack` to a non-null value (local shadow), so no call sites needed touching. The four sites bail out at the appropriate scope: `BottomPlayer`'s outer Box, `ExpandedPlayer`'s two inner Column/Row scopes, `PlaybackControl`'s Column.

The parent (`PlayerScreen`) gates the entire sheet via `AnimatedVisibility(visible = currentTrack != null, …)`, but `AnimatedVisibility` keeps composing the child for the duration of the exit animation — that's the gap these guards close.

### TrackInfoSheet.kt — two sites
Both `Changes` and `ManualEditing` child routes passed `state.track!!`:

```kotlin
val track = state.track ?: return@composable
ChangesSheet(track = track, …)   // and ManualInfoEditSheet
```

If a navigation child renders before its parent populated `state.track`, the route no-ops instead of crashing.

### Version
- `versionCode 1_003_000 → 1_003_001`
- `versionName 1.3.0-community → 1.3.1-community`

## Test plan

- [ ] Existing playback flow unchanged: open app → play track → expand sheet → controls work, lyrics work, seek bar works
- [ ] Edit a track's metadata via the track menu → "Track info" → "Changes" / "Manual editing" sub-screens both still render the track
- [ ] State race on the player sheet: tap stop / clear queue while the expanded sheet is open → sheet animates out cleanly, no crash (previously could crash if the recomposition saw `currentTrack == null` mid-animation)
- [ ] Backgrounding and resuming the app while a track is playing → sheet re-renders normally
- [ ] After merge + tag `v1.3.1`: CHANGELOG-driven release notes appear, all five APKs ship

---

## Phase 3 roadmap status

- ✅ #1 — Drop Realm (v1.3.0, shipped)
- ✅ #2 — Remove `!!` (this PR, v1.3.1)
- ⏳ #3 — `PlayerViewModel` god-file split (next, v1.3.2)
- ⏳ #4 — Lint / detekt / ktlint baselines burn-down + flip strict (after VM split, v1.3.3)

(Reordered #3 / #4 from the original list — null-safety done first because it was the smallest and highest-stability win.)

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp)_