### PR TITLE
refactor(vm): extract LyricsFetcher — Phase 3 #3 first pass (v1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.3.2 — Extract LyricsFetcher out of PlayerViewModel
+
+**Layman:** Code cleanup with no visible changes. `PlayerViewModel`
+has grown into a 1541-line file handling playback, metadata,
+playlists, lyrics, and more — all mixed together. This release
+extracts the lyrics fetching logic into its own focused class so
+future work on lyrics doesn't drag the whole file into every diff.
+First step in a multi-release split; the behaviour on your phone is
+unchanged.
+
+**Technical:**
+- Phase 3 cleanup, item 3 of 4 (first pass). Pure extraction — no
+  state-coupling changes, no behaviour changes, no public API changes.
+- New `com.dn0ne.player.app.domain.lyrics.LyricsFetcher` class owns
+  the two formerly private methods `readFromTag` and `fetchFromRemote`
+  (previously `readLyricsFromTag` / `fetchLyrics` inside the VM).
+  Constructor takes `LyricsReader`, `LyricsProvider`, `LyricsRepository`.
+- `PlayerViewModel` now holds a private `lyricsFetcher` field and
+  delegates at the three call sites (`OnLyricsControlClick`,
+  `OnFetchLyricsFromRemoteClick`, `loadLyrics`). `readFromTag` takes
+  the coroutine scope explicitly so snackbar errors keep launching
+  off `viewModelScope` exactly as before.
+- Net: `-102 lines` in `PlayerViewModel.kt` (1541 → 1439). Remaining
+  slices — metadata search, playlist CRUD, queue ops, lyrics control
+  sheet state — stay in the VM for now; they'll be pulled out in
+  follow-up PRs once this pattern is proven in production.
+
 ## 1.3.1 — Stability: remove force-unwraps from playback UI
 
 **Layman:** Pure stability fix, no visible changes. The player sheet

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_003_001
-        versionName = "1.3.1-community"
+        versionCode = 1_003_002
+        versionName = "1.3.2-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/domain/lyrics/LyricsFetcher.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/lyrics/LyricsFetcher.kt
@@ -1,0 +1,85 @@
+package com.dn0ne.player.app.domain.lyrics
+
+import com.dn0ne.player.R
+import com.dn0ne.player.app.data.LyricsReader
+import com.dn0ne.player.app.data.remote.lyrics.LyricsProvider
+import com.dn0ne.player.app.data.repository.LyricsRepository
+import com.dn0ne.player.app.domain.result.DataError
+import com.dn0ne.player.app.domain.result.Result
+import com.dn0ne.player.app.domain.track.Track
+import com.dn0ne.player.app.presentation.components.snackbar.SnackbarController
+import com.dn0ne.player.app.presentation.components.snackbar.SnackbarEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Small facade around the three lyrics data sources. Extracted from
+ * `PlayerViewModel` to keep the VM focused on playback + navigation state;
+ * user-visible snackbar handling is preserved exactly as the VM had it so
+ * this is a pure move, not a behaviour change.
+ */
+class LyricsFetcher(
+    private val lyricsReader: LyricsReader,
+    private val lyricsProvider: LyricsProvider,
+    private val lyricsRepository: LyricsRepository,
+) {
+
+    /**
+     * Reads embedded lyrics from the file's ID3/Vorbis tags. Synchronous —
+     * `LyricsReader` already handles the heavy I/O. Errors surface as a
+     * snackbar launched on [scope] so callers don't block on the UI thread.
+     */
+    fun readFromTag(track: Track, scope: CoroutineScope): Lyrics? {
+        val readResult = lyricsReader.readFromTag(track)
+        return when (readResult) {
+            is Result.Success -> readResult.data
+            is Result.Error -> {
+                val messageRes = when (readResult.error) {
+                    DataError.Local.NoReadPermission -> R.string.no_read_permission
+                    DataError.Local.FailedToRead -> R.string.failed_to_read
+                    else -> R.string.unknown_error_occurred
+                }
+                scope.launch {
+                    SnackbarController.sendEvent(SnackbarEvent(message = messageRes))
+                }
+                null
+            }
+        }
+    }
+
+    /**
+     * Fetches lyrics from the configured remote provider (LRCLIB). Caches a
+     * successful result in the local repository. Network / parse errors
+     * surface as snackbars; no exception escapes.
+     */
+    suspend fun fetchFromRemote(track: Track): Lyrics? = withContext(Dispatchers.IO) {
+        if (track.title == null || track.artist == null) {
+            SnackbarController.sendEvent(
+                SnackbarEvent(message = R.string.cant_look_for_lyrics_title_or_artist_is_missing)
+            )
+            return@withContext null
+        }
+
+        when (val result = lyricsProvider.getLyrics(track)) {
+            is Result.Success -> {
+                val lyrics = result.data
+                lyricsRepository.insertLyrics(lyrics)
+                lyrics
+            }
+            is Result.Error -> {
+                val messageRes = when (result.error) {
+                    DataError.Network.BadRequest ->
+                        R.string.cant_look_for_lyrics_title_or_artist_is_missing
+                    DataError.Network.NotFound -> R.string.lyrics_not_found
+                    DataError.Network.ParseError -> R.string.failed_to_parse_response
+                    DataError.Network.NoInternet -> R.string.no_internet
+                    else -> R.string.unknown_error_occurred
+                }
+                SnackbarController.sendEvent(SnackbarEvent(message = messageRes))
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
@@ -20,6 +20,7 @@ import com.dn0ne.player.app.data.repository.LyricsRepository
 import com.dn0ne.player.app.data.repository.PlaylistRepository
 import com.dn0ne.player.app.data.repository.TrackRepository
 import com.dn0ne.player.app.domain.lyrics.Lyrics
+import com.dn0ne.player.app.domain.lyrics.LyricsFetcher
 import com.dn0ne.player.app.domain.lyrics.toSyncedLyrics
 import com.dn0ne.player.app.domain.metadata.Metadata
 import com.dn0ne.player.app.domain.playback.PlaybackMode
@@ -70,6 +71,15 @@ class PlayerViewModel(
     private val equalizerController: EqualizerController
 ) : ViewModel() {
     var player: Player? = null
+
+    // Self-contained facade for reading embedded lyrics from tags and
+    // fetching them from LRCLIB. Same behaviour as before, just moved out
+    // of this class so the VM can shrink.
+    private val lyricsFetcher = LyricsFetcher(
+        lyricsReader = lyricsReader,
+        lyricsProvider = lyricsProvider,
+        lyricsRepository = lyricsRepository,
+    )
 
     private val _settingsSheetState = MutableStateFlow(
         SettingsSheetState(
@@ -1093,7 +1103,7 @@ class PlayerViewModel(
                     val track = _trackInfoSheetState.value.track ?: return@launch
 
                     val lyricsFromRepository = lyricsRepository.getLyricsByUri(track.uri.toString())
-                    var lyricsFromTag: Lyrics? = readLyricsFromTag(track)
+                    var lyricsFromTag: Lyrics? = lyricsFetcher.readFromTag(track, viewModelScope)
 
                     _lyricsControlSheetState.update {
                         it.copy(
@@ -1163,7 +1173,7 @@ class PlayerViewModel(
 
                         delay(5000)
 
-                        val fromTag = readLyricsFromTag(track)
+                        val fromTag = lyricsFetcher.readFromTag(track, viewModelScope)
                         _lyricsControlSheetState.update {
                             it.copy(
                                 lyricsFromTag = fromTag,
@@ -1182,7 +1192,7 @@ class PlayerViewModel(
                             isFetchingFromRemote = true
                         )
                     }
-                    val lyrics = fetchLyrics(track)
+                    val lyrics = lyricsFetcher.fetchFromRemote(track)
 
                     _lyricsControlSheetState.update {
                         it.copy(
@@ -1371,118 +1381,6 @@ class PlayerViewModel(
         }
     }
 
-    private fun readLyricsFromTag(track: Track): Lyrics? {
-        var lyrics: Lyrics? = null
-
-        val readResult = lyricsReader.readFromTag(track)
-        when (readResult) {
-            is Result.Success -> {
-                lyrics = readResult.data
-            }
-
-            is Result.Error -> {
-                viewModelScope.launch {
-                    when (readResult.error) {
-                        DataError.Local.NoReadPermission -> {
-                            SnackbarController.sendEvent(
-                                SnackbarEvent(
-                                    message = R.string.no_read_permission
-                                )
-                            )
-                        }
-
-                        DataError.Local.FailedToRead -> {
-                            SnackbarController.sendEvent(
-                                SnackbarEvent(
-                                    message = R.string.failed_to_read
-                                )
-                            )
-                        }
-
-                        else -> {
-                            SnackbarController.sendEvent(
-                                SnackbarEvent(
-                                    message = R.string.unknown_error_occurred
-                                )
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        return lyrics
-    }
-
-    private suspend fun fetchLyrics(track: Track): Lyrics? {
-        return withContext(Dispatchers.IO) {
-            if (track.title == null || track.artist == null) {
-                SnackbarController.sendEvent(
-                    SnackbarEvent(
-                        message = R.string.cant_look_for_lyrics_title_or_artist_is_missing
-                    )
-                )
-                return@withContext null
-            }
-
-            var lyrics: Lyrics? = null
-            val result = lyricsProvider.getLyrics(track)
-
-            when (result) {
-                is Result.Success -> {
-                    lyrics = result.data
-                    lyricsRepository.insertLyrics(lyrics)
-                }
-
-                is Result.Error -> {
-                    when (result.error) {
-                        DataError.Network.BadRequest -> {
-                            SnackbarController.sendEvent(
-                                SnackbarEvent(
-                                    message = R.string.cant_look_for_lyrics_title_or_artist_is_missing
-                                )
-                            )
-                        }
-
-                        DataError.Network.NotFound -> {
-                            SnackbarController.sendEvent(
-                                SnackbarEvent(
-                                    message = R.string.lyrics_not_found
-                                )
-                            )
-                        }
-
-                        DataError.Network.ParseError -> {
-                            SnackbarController.sendEvent(
-                                SnackbarEvent(
-                                    message = R.string.failed_to_parse_response
-                                )
-                            )
-                        }
-
-                        DataError.Network.NoInternet -> {
-                            SnackbarController.sendEvent(
-                                SnackbarEvent(
-                                    message = R.string.no_internet
-                                )
-                            )
-                        }
-
-                        else -> {
-                            SnackbarController.sendEvent(
-                                SnackbarEvent(
-                                    message = R.string.unknown_error_occurred
-                                )
-                            )
-                        }
-                    }
-                }
-            }
-
-            lyrics
-        }
-    }
-
     private fun loadLyrics() {
         _playbackState.value.currentTrack?.let { currentTrack ->
             if (currentTrack.uri.toString() == _playbackState.value.lyrics?.uri) return
@@ -1496,7 +1394,8 @@ class PlayerViewModel(
                 }
 
                 var lyrics: Lyrics? = lyricsRepository.getLyricsByUri(currentTrack.uri.toString())
-                    ?: fetchLyrics(currentTrack) ?: readLyricsFromTag(currentTrack)
+                    ?: lyricsFetcher.fetchFromRemote(currentTrack)
+                    ?: lyricsFetcher.readFromTag(currentTrack, viewModelScope)
                         ?.also { lyricsRepository.insertLyrics(it) }
 
                 _playbackState.update {


### PR DESCRIPTION
## What's in v1.3.2

Phase 3 cleanup, **item 3 of 4, first pass**. Pure extraction from `PlayerViewModel` — no behaviour change.

**Layman:** Code cleanup with no visible changes. `PlayerViewModel` has grown into a 1541-line file handling playback, metadata, playlists, lyrics, and more — all mixed together. This release extracts the lyrics fetching logic into its own focused class so future work on lyrics doesn't drag the whole file into every diff. First step in a multi-release split; behaviour on your phone is unchanged.

**Technical:**

### New class

`com.dn0ne.player.app.domain.lyrics.LyricsFetcher` — owns the two formerly private methods that were inside `PlayerViewModel`:

| Before (in VM) | After |
| --- | --- |
| `private fun readLyricsFromTag(track: Track): Lyrics?` | `LyricsFetcher.readFromTag(track, scope)` |
| `private suspend fun fetchLyrics(track: Track): Lyrics?` | `LyricsFetcher.fetchFromRemote(track)` |

Constructor takes `LyricsReader`, `LyricsProvider`, `LyricsRepository`. Snackbar error handling is preserved verbatim — the tag-read variant now takes an explicit `CoroutineScope` so its error snackbar keeps launching off `viewModelScope` exactly as before.

### Call-site migration

Three sites in `PlayerViewModel` now delegate:
- `OnLyricsControlClick` → `lyricsFetcher.readFromTag(track, viewModelScope)`
- `OnFetchLyricsFromRemoteClick` → `lyricsFetcher.fetchFromRemote(track)`
- `loadLyrics()` → `lyricsFetcher.fetchFromRemote(...) ?: lyricsFetcher.readFromTag(..., viewModelScope)`

Private methods `readLyricsFromTag` + `fetchLyrics` deleted from the VM.

### Scope

- `PlayerViewModel.kt`: **1541 → 1439 lines** (−102).
- Remaining VM slices (metadata search, playlist CRUD, queue ops, lyrics-control sheet state) stay in place for now. They'll be pulled out in follow-up PRs once this pattern is proven in production.

### Why a narrow first pass

Full splits of a god file are risky without local Gradle (I can't run tests during development). Starting with the two helpers that have zero state coupling — they're pure pass-through functions — lets CI verify the pattern is clean, then subsequent extractions can lean on the same shape.

### Version

- `versionCode 1_003_001 → 1_003_002`
- `versionName 1.3.1-community → 1.3.2-community`

## Test plan

- [ ] Read embedded lyrics from a tagged MP3 → track info shows the lyrics (uses `readFromTag`)
- [ ] Fetch lyrics from LRCLIB for a track that LRCLIB has → lyrics appear, snackbar "success" style (uses `fetchFromRemote`)
- [ ] Fetch lyrics for a track LRCLIB doesn't know → "lyrics not found" snackbar (same snackbar as before the refactor)
- [ ] Open the lyrics control sheet → it loads the right lyrics (via `loadLyrics` delegation)
- [ ] After merge + tag `v1.3.2`: CHANGELOG-driven release notes appear, all five APKs ship

---

## Phase 3 roadmap status

- ✅ #1 — Drop Realm (v1.3.0)
- ✅ #2 — Remove `!!` (v1.3.1)
- 🟡 #3 — VM split (this PR, v1.3.2 — first pass extracts lyrics; follow-up PRs will pull metadata / playlists / queue)
- ⏳ #4 — Lint / detekt / ktlint baselines burn-down + flip strict (after #3 completes, v1.3.3+)

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp)_