### PR TITLE
refactor(vm): extract PlaylistEditor — Phase 3 #3 second pass (v1.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.3.3 — Extract PlaylistEditor out of PlayerViewModel
+
+**Layman:** Second step in the PlayerViewModel cleanup begun in 1.3.2.
+All the "create / rename / delete / add / remove / reorder" playlist
+operations move into their own class. No visible change on your phone
+— same behaviour, same snackbars, same results.
+
+**Technical:**
+- Phase 3 cleanup, item 3 of 4 (second pass). Another pure extraction.
+- New `com.dn0ne.player.app.domain.playlist.PlaylistEditor` class with
+  six `suspend` methods — `create`, `rename`, `delete`, `addTracks`,
+  `removeTracks`, `reorder`. Constructor takes `PlaylistRepository`.
+- The name-collision check (previously `playlists.value.map { it.name
+  }.contains(event.name)`) now takes an explicit `existingNames`
+  list. Name checks, snackbars, and the "add tracks that are already
+  present still adds them" quirk are all preserved exactly.
+- Six `PlayerScreenEvent` branches in the VM — `OnCreatePlaylistClick`,
+  `OnRenamePlaylistClick`, `OnDeletePlaylistClick`, `OnAddToPlaylist`,
+  `OnRemoveFromPlaylist`, `OnPlaylistReorder` — now delegate to the
+  editor. `_selectedPlaylist` mutations stay in the branches because
+  they're VM-local state.
+- `parseM3U` still calls `playlistRepository.insertPlaylist` directly
+  — its behaviour (no name-collision check) differs from the editor
+  and is kept identical to avoid a behavioural change in this
+  refactor.
+- Net: `PlayerViewModel.kt` **1439 → 1412 lines** (−27). Combined with
+  v1.3.2 that's −129 lines total out of the 1541-line original.
+
 ## 1.3.2 — Extract LyricsFetcher out of PlayerViewModel
 
 **Layman:** Code cleanup with no visible changes. `PlayerViewModel`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_003_002
-        versionName = "1.3.2-community"
+        versionCode = 1_003_003
+        versionName = "1.3.3-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/domain/playlist/PlaylistEditor.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/playlist/PlaylistEditor.kt
@@ -1,0 +1,82 @@
+package com.dn0ne.player.app.domain.playlist
+
+import com.dn0ne.player.R
+import com.dn0ne.player.app.data.repository.PlaylistRepository
+import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.domain.track.Track
+import com.dn0ne.player.app.presentation.components.snackbar.SnackbarController
+import com.dn0ne.player.app.presentation.components.snackbar.SnackbarEvent
+
+/**
+ * Thin wrapper around the playlist repository for the mutation-side
+ * operations (create, rename, delete, add/remove/reorder tracks). Extracted
+ * from `PlayerViewModel` so the VM can shrink — behaviour is identical to
+ * the inline branches it replaces, including the "already on playlist"
+ * snackbar that fires even when we proceed to add the remaining tracks.
+ *
+ * All methods are `suspend`; the VM keeps responsibility for `viewModelScope`
+ * so cancellation semantics don't change.
+ */
+class PlaylistEditor(
+    private val repository: PlaylistRepository,
+) {
+
+    /**
+     * @return `true` if inserted, `false` if another playlist with that name
+     * already exists (duplicate names are not allowed at the UI layer).
+     */
+    suspend fun create(name: String, existingNames: List<String?>): Boolean {
+        if (name in existingNames) return false
+        repository.insertPlaylist(Playlist(name = name, trackList = emptyList()))
+        return true
+    }
+
+    /**
+     * @return `true` if renamed, `false` if another playlist already has the
+     * new name.
+     */
+    suspend fun rename(
+        playlist: Playlist,
+        newName: String,
+        existingNames: List<String?>,
+    ): Boolean {
+        if (newName in existingNames) return false
+        repository.renamePlaylist(playlist = playlist, name = newName)
+        return true
+    }
+
+    suspend fun delete(playlist: Playlist) {
+        repository.deletePlaylist(playlist = playlist)
+    }
+
+    /**
+     * Appends [tracks] to [playlist]. If any requested track is already
+     * present, emits a snackbar; the non-duplicate tracks are still added
+     * (preserved behaviour from the original VM branch).
+     *
+     * @return the playlist's new full track list.
+     */
+    suspend fun addTracks(playlist: Playlist, tracks: List<Track>): List<Track> {
+        if (playlist.trackList.any { it in tracks }) {
+            SnackbarController.sendEvent(
+                SnackbarEvent(message = R.string.track_is_already_on_playlist)
+            )
+        }
+        val newTrackList = (playlist.trackList.toMutableSet() + tracks).toList()
+        repository.updatePlaylistTrackList(playlist = playlist, trackList = newTrackList)
+        return newTrackList
+    }
+
+    /** @return the playlist's track list with [tracks] removed. */
+    suspend fun removeTracks(playlist: Playlist, tracks: List<Track>): List<Track> {
+        val newTrackList = playlist.trackList.toMutableList().apply { removeAll(tracks) }
+        repository.updatePlaylistTrackList(playlist = playlist, trackList = newTrackList)
+        return newTrackList
+    }
+
+    /** No-op if [newOrder] is structurally identical to the existing list. */
+    suspend fun reorder(playlist: Playlist, newOrder: List<Track>) {
+        if (playlist.trackList == newOrder) return
+        repository.updatePlaylistTrackList(playlist = playlist, trackList = newOrder)
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
@@ -21,6 +21,7 @@ import com.dn0ne.player.app.data.repository.PlaylistRepository
 import com.dn0ne.player.app.data.repository.TrackRepository
 import com.dn0ne.player.app.domain.lyrics.Lyrics
 import com.dn0ne.player.app.domain.lyrics.LyricsFetcher
+import com.dn0ne.player.app.domain.playlist.PlaylistEditor
 import com.dn0ne.player.app.domain.lyrics.toSyncedLyrics
 import com.dn0ne.player.app.domain.metadata.Metadata
 import com.dn0ne.player.app.domain.playback.PlaybackMode
@@ -80,6 +81,10 @@ class PlayerViewModel(
         lyricsProvider = lyricsProvider,
         lyricsRepository = lyricsRepository,
     )
+
+    // Mutation-side playlist operations (create/rename/delete/add/remove/reorder).
+    // VM-owned state updates (`_selectedPlaylist`) stay in the event branches.
+    private val playlistEditor = PlaylistEditor(repository = playlistRepository)
 
     private val _settingsSheetState = MutableStateFlow(
         SettingsSheetState(
@@ -983,94 +988,61 @@ class PlayerViewModel(
 
             is OnCreatePlaylistClick -> {
                 viewModelScope.launch {
-                    if (playlists.value.map { it.name }.contains(event.name)) return@launch
-                    playlistRepository.insertPlaylist(
-                        Playlist(
-                            name = event.name,
-                            trackList = emptyList()
-                        )
+                    playlistEditor.create(
+                        name = event.name,
+                        existingNames = playlists.value.map { it.name },
                     )
                 }
             }
 
             is OnRenamePlaylistClick -> {
                 viewModelScope.launch {
-                    if (playlists.value.map { it.name }.contains(event.name)) return@launch
-                    playlistRepository.renamePlaylist(
+                    val renamed = playlistEditor.rename(
                         playlist = event.playlist,
-                        name = event.name
+                        newName = event.name,
+                        existingNames = playlists.value.map { it.name },
                     )
-
-                    _selectedPlaylist.update {
-                        it?.copy(
-                            name = event.name
-                        )
+                    if (renamed) {
+                        _selectedPlaylist.update { it?.copy(name = event.name) }
                     }
                 }
             }
 
             is OnDeletePlaylistClick -> {
                 viewModelScope.launch {
-                    playlistRepository.deletePlaylist(
-                        playlist = event.playlist
-                    )
-
+                    playlistEditor.delete(event.playlist)
                     _selectedPlaylist.update { null }
                 }
             }
 
             is OnAddToPlaylist -> {
                 viewModelScope.launch {
-                    if (event.playlist.trackList.any { it in event.tracks }) {
-                        SnackbarController.sendEvent(
-                            SnackbarEvent(
-                                message = R.string.track_is_already_on_playlist
-                            )
-                        )
-                    }
-
-                    val newTrackList =
-                        (event.playlist.trackList.toMutableSet() + event.tracks).toList()
-                    playlistRepository.updatePlaylistTrackList(
+                    playlistEditor.addTracks(
                         playlist = event.playlist,
-                        trackList = newTrackList
+                        tracks = event.tracks,
                     )
                 }
             }
 
             is OnRemoveFromPlaylist -> {
                 viewModelScope.launch {
-                    val newTrackList = event.playlist.trackList.toMutableList().apply {
-                        removeAll(event.tracks)
-                    }
-
-                    playlistRepository.updatePlaylistTrackList(
+                    val newTrackList = playlistEditor.removeTracks(
                         playlist = event.playlist,
-                        trackList = newTrackList
+                        tracks = event.tracks,
                     )
-
-                    _selectedPlaylist.update {
-                        it?.copy(
-                            trackList = newTrackList
-                        )
-                    }
+                    _selectedPlaylist.update { it?.copy(trackList = newTrackList) }
                 }
             }
 
             is OnPlaylistReorder -> {
                 if (event.playlist.trackList != event.trackList) {
                     viewModelScope.launch {
-                        playlistRepository.updatePlaylistTrackList(
+                        playlistEditor.reorder(
                             playlist = event.playlist,
-                            trackList = event.trackList
+                            newOrder = event.trackList,
                         )
                     }
-
-                    _selectedPlaylist.update {
-                        it?.copy(
-                            trackList = event.trackList
-                        )
-                    }
+                    _selectedPlaylist.update { it?.copy(trackList = event.trackList) }
                 }
             }
 


### PR DESCRIPTION
## What's in v1.3.3

Phase 3 cleanup, **item 3 of 4, second pass**. Pure extraction from `PlayerViewModel`, no behaviour change. Continues the split begun in v1.3.2 with `LyricsFetcher`.

**Layman:** Code cleanup with no visible changes. All the "create / rename / delete / add / remove / reorder" playlist operations move into their own class. Same snackbars, same behaviour.

**Technical:**

### New class

`com.dn0ne.player.app.domain.playlist.PlaylistEditor` — six `suspend` methods:

| Method | Before (inline in VM) | After |
| --- | --- | --- |
| `create(name, existingNames): Boolean` | `OnCreatePlaylistClick` branch | delegated |
| `rename(playlist, newName, existingNames): Boolean` | `OnRenamePlaylistClick` | delegated |
| `delete(playlist)` | `OnDeletePlaylistClick` | delegated |
| `addTracks(playlist, tracks): List<Track>` | `OnAddToPlaylist` | delegated |
| `removeTracks(playlist, tracks): List<Track>` | `OnRemoveFromPlaylist` | delegated |
| `reorder(playlist, newOrder)` | `OnPlaylistReorder` | delegated |

Constructor takes `PlaylistRepository`. Name-collision check now takes an explicit `existingNames` list so the editor has no knowledge of the VM's `playlists` `StateFlow`. The quirky "if any requested track is already on the playlist, fire a snackbar but still add the others" behaviour is preserved verbatim — pure extraction, not a correctness fix.

### VM-local state stays in VM

`_selectedPlaylist` mutations stay in the event branches after the editor call — the editor doesn't know about them. Example for rename:

```kotlin
is OnRenamePlaylistClick -> {
    viewModelScope.launch {
        val renamed = playlistEditor.rename(
            playlist = event.playlist,
            newName = event.name,
            existingNames = playlists.value.map { it.name },
        )
        if (renamed) {
            _selectedPlaylist.update { it?.copy(name = event.name) }
        }
    }
}
```

### Exception

`parseM3U` still calls `playlistRepository.insertPlaylist` directly. Its behaviour (no name-collision check) differs from `PlaylistEditor.create`, and routing it through the editor would be a behavioural change we shouldn't bundle into this refactor.

### Scope

- `PlayerViewModel.kt`: **1439 → 1412 lines** (−27).
- Combined with v1.3.2: **−129 lines total** from the 1541-line original.

### Version

- `versionCode 1_003_002 → 1_003_003`
- `versionName 1.3.2-community → 1.3.3-community`

## Test plan

- [ ] Create a new playlist → it appears in Playlists tab
- [ ] Try creating a second playlist with the same name → silently skipped (existing behaviour)
- [ ] Rename an existing playlist → new name shows in list and the open playlist header
- [ ] Delete a playlist while viewing it → playlist disappears, returned to main screen
- [ ] Add a track already on the playlist → "already on playlist" snackbar appears, other new tracks are added
- [ ] Remove tracks from a playlist while viewing it → tracks gone, remaining list updates live
- [ ] Reorder tracks in a playlist (drag handle) → order persists
- [ ] Parse an M3U (from global search? or wherever that's invoked) still creates a playlist
- [ ] After merge + tag `v1.3.3`: CHANGELOG-driven release notes appear, all five APKs ship

---

## Phase 3 roadmap status

- ✅ #1 — Drop Realm (v1.3.0)
- ✅ #2 — Remove `!!` (v1.3.1)
- 🟡 #3 — VM split: lyrics ✅ (v1.3.2) · playlists ✅ (this PR, v1.3.3) · **next: queue ops** (v1.3.4)
- ⏳ #4 — Lint / detekt / ktlint baselines (after #3 completes)

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp)_