### PR TITLE
fix(notification): show song title + artwork — Phase 4 #1 (v1.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.3.4 — Fix media notification: show song title, artist, and artwork
+
+**Layman:** When you play a song, the system notification (and the
+lock screen, and Android Auto, and your watch's media tile) used to
+say just "Lotus is playing" instead of the actual song title.
+Embarrassing. Fixed: every track now carries its title, artist, album,
+album art, year, and track number into the notification, so you
+finally see what's playing.
+
+**Technical:**
+- Phase 4, item 1. Stability + modernization fix.
+- Root cause: both Track → MediaItem conversion sites
+  (`TrackRepositoryImpl` at scan time and `TrackSerializer` at saved-
+  state restore time) called `MediaItem.fromUri(uri)`, which builds a
+  `MediaItem` with **no** `MediaMetadata`. Media3's automatic
+  notification reads `mediaMetadata.title` / `displayTitle`, so when
+  both are null the system fell back to the app label.
+- New helper: `com.dn0ne.player.app.domain.track.buildMediaItem(uri,
+  title, artist, album, albumArtist, genre, year, trackNumber,
+  coverArtUri)`. Single source of truth for Track → MediaItem with
+  full `MediaMetadata` populated:
+  - `title`, `artist`, `albumTitle`, `albumArtist`, `genre`
+  - `releaseYear`, `trackNumber` (parsed via `?.toIntOrNull()` so
+    weirdly-formatted tags don't crash)
+  - `artworkUri` from the MediaStore album-art URI (system-loaded —
+    no manual bitmap decode)
+  - `displayTitle` + `subtitle` set explicitly because different
+    OEMs prefer different fields for the notification's primary /
+    secondary lines
+  - stable `mediaId` = uri string, plus `RequestMetadata.mediaUri`
+    for MediaSession correlation across queue reorders + process
+    restarts
+- Two call sites migrated to `buildMediaItem(...)`. Unused
+  `androidx.media3.common.MediaItem` import removed from
+  `TrackSerializer`.
+- Modernisation: `POST_NOTIFICATIONS` permission added to the
+  manifest. Required on Android 13+ for foreground-service media
+  notifications to be reliably visible. The system handles the runtime
+  prompt automatically when the foreground service starts.
+
 ## 1.3.3 — Extract PlaylistEditor out of PlayerViewModel
 
 **Layman:** Second step in the PlayerViewModel cleanup begun in 1.3.2.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_003_003
-        versionName = "1.3.3-community"
+        versionCode = 1_003_004
+        versionName = "1.3.4-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,11 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- Required on Android 13+ (API 33) so the foreground-service media
+         notification with track title / artwork is visible to the user.
+         The system handles the runtime permission prompt for media-style
+         notifications when the foreground service starts. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/TrackRepositoryImpl.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/TrackRepositoryImpl.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.util.fastForEach
 import androidx.core.database.getIntOrNull
 import androidx.core.database.getLongOrNull
 import androidx.core.database.getStringOrNull
-import androidx.media3.common.MediaItem
 import com.dn0ne.player.app.domain.track.Track
+import com.dn0ne.player.app.domain.track.buildMediaItem
 import com.dn0ne.player.core.data.Settings
 import java.util.concurrent.TimeUnit
 
@@ -148,7 +148,17 @@ class TrackRepositoryImpl(
                     Uri.parse("content://media/external/audio/albumart"),
                     albumId
                 )
-                val mediaItem = MediaItem.fromUri(uri)
+                val mediaItem = buildMediaItem(
+                    uri = uri,
+                    title = title,
+                    artist = artist,
+                    album = album,
+                    albumArtist = albumArtist,
+                    genre = genre,
+                    year = year,
+                    trackNumber = trackNumber,
+                    coverArtUri = albumArtUri,
+                )
 
                 tracks += Track(
                     uri = uri,

--- a/app/src/main/java/com/dn0ne/player/app/domain/track/MediaItemBuilder.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/track/MediaItemBuilder.kt
@@ -1,0 +1,60 @@
+package com.dn0ne.player.app.domain.track
+
+import android.net.Uri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+
+/**
+ * Build a Media3 [MediaItem] with full [MediaMetadata] populated.
+ *
+ * Without this metadata, the system media notification falls back to the
+ * app name ("Lotus is playing") because there's no track title to show.
+ * This helper is the single source of truth for Track → MediaItem
+ * conversion, used both at scan time ([TrackRepositoryImpl]) and when
+ * deserialising saved player state ([TrackSerializer]).
+ *
+ * `displayTitle` and `subtitle` are set explicitly so the notification's
+ * primary line and secondary line are stable across Android versions —
+ * different OEMs prefer different fields, setting both is the safe move.
+ *
+ * `artworkUri` points at the MediaStore album-art URI; the system loads
+ * it into the notification + lockscreen + Android Auto / Wear without us
+ * decoding the bitmap ourselves.
+ */
+fun buildMediaItem(
+    uri: Uri,
+    title: String?,
+    artist: String?,
+    album: String?,
+    albumArtist: String?,
+    genre: String?,
+    year: String?,
+    trackNumber: String?,
+    coverArtUri: Uri?,
+): MediaItem {
+    val metadata = MediaMetadata.Builder()
+        .setTitle(title)
+        .setArtist(artist)
+        .setAlbumTitle(album)
+        .setAlbumArtist(albumArtist)
+        .setGenre(genre)
+        .setReleaseYear(year?.toIntOrNull())
+        .setTrackNumber(trackNumber?.toIntOrNull())
+        .setArtworkUri(coverArtUri)
+        .setDisplayTitle(title)
+        .setSubtitle(artist)
+        .build()
+
+    return MediaItem.Builder()
+        .setUri(uri)
+        // Stable id so the MediaSession can correlate "this is the same
+        // track" across queue reorders and process restarts.
+        .setMediaId(uri.toString())
+        .setMediaMetadata(metadata)
+        .setRequestMetadata(
+            MediaItem.RequestMetadata.Builder()
+                .setMediaUri(uri)
+                .build()
+        )
+        .build()
+}

--- a/app/src/main/java/com/dn0ne/player/app/domain/track/TrackSerializer.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/track/TrackSerializer.kt
@@ -1,7 +1,6 @@
 package com.dn0ne.player.app.domain.track
 
 import android.net.Uri
-import androidx.media3.common.MediaItem
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
@@ -97,8 +96,21 @@ object TrackSerializer : KSerializer<Track> {
             require(uriString.isNotBlank() && coverArtUriString.isNotBlank() && duration >= 0 && size >= 0)
 
             val uri = Uri.parse(uriString)
-            val mediaItem = MediaItem.fromUri(uri)
             val coverArtUri = Uri.parse(coverArtUriString)
+            // Rebuild the MediaItem with full metadata so the system media
+            // notification has a title / artist / artwork to show after a
+            // process restart, not just "Lotus is playing".
+            val mediaItem = buildMediaItem(
+                uri = uri,
+                title = title,
+                artist = artist,
+                album = album,
+                albumArtist = albumArtist,
+                genre = genre,
+                year = year,
+                trackNumber = trackNumber,
+                coverArtUri = coverArtUri,
+            )
             Track(
                 uri = uri,
                 mediaItem = mediaItem,


### PR DESCRIPTION
## What's in v1.3.4

Phase 4, **item 1 of 3**. Bug fix + Android 13+ modernization. Stability paramount.

**Layman:** When you play a song, the system notification (and the lock screen, Android Auto, your watch's media tile) used to show "Lotus is playing" instead of the actual song title. Embarrassing — fixed. Every track now carries its title, artist, album, album art, year, and track number into the notification, so you finally see what's playing.

**Technical:**

### Root cause

Both Track → MediaItem conversion sites called `MediaItem.fromUri(uri)`, which builds a `MediaItem` with **no** `MediaMetadata`. Media3's automatic notification reads `mediaMetadata.title` / `displayTitle`, so when both are null the system fell back to the app label.

| File | Line | Trigger |
| --- | --- | --- |
| `app/data/repository/TrackRepositoryImpl.kt` | 151 | At MediaStore scan time |
| `app/domain/track/TrackSerializer.kt` | 100 | At saved-state deserialise (process restart) |

### Fix — single source of truth

New helper `com.dn0ne.player.app.domain.track.buildMediaItem(...)` populates the full `MediaMetadata`:

- `title`, `artist`, `albumTitle`, `albumArtist`, `genre`
- `releaseYear`, `trackNumber` — parsed via `?.toIntOrNull()` so weird-format tags don't crash
- `artworkUri` from the MediaStore album-art URI — system-loaded; no manual `Bitmap` decode needed
- `displayTitle` + `subtitle` set explicitly. Different OEM skins prefer different fields for the notification's primary / secondary lines; setting both is the safe move.
- Stable `mediaId` = uri string for `MediaSession` correlation across queue reorders / process restarts
- `RequestMetadata.mediaUri` so the session retains the original URI

Both call sites migrated. Unused `androidx.media3.common.MediaItem` import removed from `TrackSerializer`.

### Modernization — Android 13+

`POST_NOTIFICATIONS` permission added to `AndroidManifest.xml`. Required on Android 13+ (API 33) for foreground-service media notifications to be reliably visible. The system handles the runtime prompt when the foreground service starts — no manual permission flow needed.

### Version

- `versionCode 1_003_003 → 1_003_004`
- `versionName 1.3.3-community → 1.3.4-community`

## Test plan

- [ ] Play a track → notification shows the actual song title (not "Lotus is playing")
- [ ] Lockscreen shows the album artwork
- [ ] Lockscreen / notification shows the artist as the secondary line
- [ ] Skip / pause / play from the notification still works
- [ ] Background the app, kill it, relaunch → notification re-appears with correct title (saved-state path)
- [ ] Android 13+ device → first launch may prompt for notification permission; granting shows the rich notification
- [ ] Android Auto / Wear / other media controllers (if you have one handy) — title + artwork now appear there too
- [ ] After merge + tag `v1.3.4`: CHANGELOG-driven release notes, all five APKs ship

---

## Phase 4 roadmap

- 🟡 #1 — Notification fix (this PR, v1.3.4)
- ⏳ #2 — Metadata-search crash (investigate, decide fix vs remove)
- ⏳ #3 — F-droid + itch.io distribution docs

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp)_