### PR TITLE
fix(network): MusicBrainz / LRCLIB crash hardening — Phase 4 #2 (v1.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.3.5 — Stop crashes during MusicBrainz / LRCLIB requests
+
+**Layman:** Searching online for track metadata (the "Track info →
+Search" flow) and fetching lyrics from LRCLIB used to crash the app
+on flaky networks — DNS hiccups, TLS / certificate weirdness, slow
+connections. Now those failures pop a snackbar with a helpful message
+instead of taking the app down. Also: the request timeout dropped
+from **3 minutes** to **20 seconds**, so a slow lookup gives you an
+error long before you'd reach for the back button.
+
+**Technical:**
+- Phase 4, item 2. The metadata search feature was kept (it's
+  legitimately useful for fixing badly-tagged music) and hardened
+  rather than removed.
+- Three crash-paths fixed across `MusicBrainzMetadataProvider` (2
+  network calls) and `LrclibLyricsProvider` (3 network calls). Each
+  call previously caught only a narrow set: `UnresolvedAddressException`,
+  `HttpRequestTimeoutException`, sometimes `SocketException`. Anything
+  else escaped uncaught:
+  - `ConnectTimeoutException` / `SocketTimeoutException` — connection
+    + read timeouts (distinct from `HttpRequestTimeoutException`)
+  - `UnknownHostException` — DNS failures on some Android stacks
+  - `SSLException` — TLS handshake / cert pinning errors
+  - any other `IOException` — generic socket / EOF problems
+- Both providers now use a single `Throwable.toNetworkError()`
+  classifier and a `Throwable` fallback at the end of each `catch`
+  block. `CancellationException` is explicitly re-thrown so coroutine
+  cancellation still unwinds correctly (catching it would break
+  structured concurrency).
+- `body()` parse paths gain the same `Throwable` fallback, mapping
+  to `DataError.Network.ParseError`.
+- HTTP timeouts in `PlayerModule.kt` retuned:
+  - `requestTimeoutMillis 180_000 → 20_000` (3 min → 20 s)
+  - new `connectTimeoutMillis = 10_000`
+  - new `socketTimeoutMillis = 15_000`
+- Dead code removed in `getCoverArtBytes`: a `Log.d(...)` after a
+  `return` was unreachable. Moved before the return so 307 redirect
+  responses (which Ktor follows automatically — should never reach
+  this branch in practice) actually log when they do.
+- `println("RESPONSE BODY: ...")` left over from earlier debugging in
+  `LrclibLyricsProvider.postLyrics` replaced with a proper
+  `Log.d(logTag, ...)` call.
+
 ## 1.3.4 — Fix media notification: show song title, artist, and artwork
 
 **Layman:** When you play a song, the system notification (and the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_003_004
-        versionName = "1.3.4-community"
+        versionCode = 1_003_005
+        versionName = "1.3.5-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/LrclibLyricsProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/LrclibLyricsProvider.kt
@@ -14,6 +14,8 @@ import com.dn0ne.player.app.presentation.components.snackbar.SnackbarEvent
 import com.dn0ne.player.core.util.getAppVersionName
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.get
 import io.ktor.client.request.post
@@ -26,10 +28,14 @@ import io.ktor.http.appendPathSegments
 import io.ktor.http.contentType
 import io.ktor.http.headers
 import io.ktor.serialization.JsonConvertException
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
+import java.io.IOException
 import java.net.SocketException
+import java.net.UnknownHostException
 import java.nio.channels.UnresolvedAddressException
 import java.security.MessageDigest
+import javax.net.ssl.SSLException
 
 class LrclibLyricsProvider(
     context: Context,
@@ -63,13 +69,10 @@ class LrclibLyricsProvider(
                     append(HttpHeaders.UserAgent, userAgent)
                 }
             }
-        } catch (e: UnresolvedAddressException) {
-            Log.i(logTag, e.message.toString())
-            return Result.Error(DataError.Network.NoInternet)
-        } catch (_: HttpRequestTimeoutException) {
-            return Result.Error(DataError.Network.RequestTimeout)
-        } catch (_: SocketException) {
-            return Result.Error(DataError.Network.Unknown)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            return Result.Error(e.toNetworkError())
         }
 
         when (response.status) {
@@ -93,8 +96,13 @@ class LrclibLyricsProvider(
                             synced = syncedLyrics
                         )
                     )
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: JsonConvertException) {
                     Log.d(logTag, e.message, e)
+                    return Result.Error(DataError.Network.ParseError)
+                } catch (e: Throwable) {
+                    Log.w(logTag, "Failed to parse LRCLIB response", e)
                     return Result.Error(DataError.Network.ParseError)
                 }
             }
@@ -129,20 +137,20 @@ class LrclibLyricsProvider(
                     append(HttpHeaders.UserAgent, userAgent)
                 }
             }
-        } catch (e: UnresolvedAddressException) {
-            Log.i(logTag, e.message.toString())
-            return Result.Error(DataError.Network.NoInternet)
-        } catch (_: HttpRequestTimeoutException) {
-            return Result.Error(DataError.Network.RequestTimeout)
-        } catch (_: SocketException) {
-            return Result.Error(DataError.Network.Unknown)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            return Result.Error(e.toNetworkError())
         }
 
         if (response.status != HttpStatusCode.OK) return Result.Error(DataError.Network.Unknown)
 
         val challenge = try {
             response.body<ChallengeDto>()
-        } catch (_: Exception) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.w(logTag, "Failed to parse LRCLIB challenge", e)
             return Result.Error(DataError.Network.ParseError)
         }
 
@@ -176,20 +184,49 @@ class LrclibLyricsProvider(
                     )
                 )
             }
-        } catch (e: UnresolvedAddressException) {
-            Log.i(logTag, e.message.toString())
-            return Result.Error(DataError.Network.NoInternet)
-        } catch (_: HttpRequestTimeoutException) {
-            return Result.Error(DataError.Network.RequestTimeout)
-        } catch (_: SocketException) {
-            return Result.Error(DataError.Network.Unknown)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            return Result.Error(e.toNetworkError())
         }
 
         return if (response.status == HttpStatusCode.Created) {
             Result.Success(Unit)
         } else {
-            println("RESPONSE BODY: ${response.bodyAsText()}")
+            Log.d(logTag, "Publish failed: ${response.status} ${response.bodyAsText()}")
             Result.Error(DataError.Network.Unknown)
+        }
+    }
+
+    /**
+     * Maps any thrown network-side exception onto our [DataError.Network]
+     * vocabulary. The previous code only caught a handful of types and
+     * everything else escaped, which is why a flaky-network "post lyrics"
+     * could crash the app.
+     */
+    private fun Throwable.toNetworkError(): DataError.Network {
+        return when (this) {
+            is UnresolvedAddressException, is UnknownHostException -> {
+                Log.i(logTag, "DNS / address resolution failed: $message")
+                DataError.Network.NoInternet
+            }
+            is HttpRequestTimeoutException,
+            is ConnectTimeoutException,
+            is SocketTimeoutException -> {
+                DataError.Network.RequestTimeout
+            }
+            is SSLException -> {
+                Log.w(logTag, "TLS handshake / cert error: $message")
+                DataError.Network.Unknown
+            }
+            is SocketException, is IOException -> {
+                Log.w(logTag, "Network I/O error: $message")
+                DataError.Network.Unknown
+            }
+            else -> {
+                Log.w(logTag, "Unexpected network failure", this)
+                DataError.Network.Unknown
+            }
         }
     }
 

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/metadata/MusicBrainzMetadataProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/metadata/MusicBrainzMetadataProvider.kt
@@ -8,6 +8,8 @@ import com.dn0ne.player.app.domain.result.DataError
 import com.dn0ne.player.app.domain.result.Result
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
@@ -17,11 +19,15 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.appendPathSegments
 import io.ktor.http.headers
 import io.ktor.serialization.JsonConvertException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.io.IOException
 import java.net.SocketException
+import java.net.UnknownHostException
 import java.nio.channels.UnresolvedAddressException
+import javax.net.ssl.SSLException
 import com.dn0ne.player.R
 import com.dn0ne.player.core.util.getAppVersionName
 
@@ -58,13 +64,11 @@ class MusicBrainzMetadataProvider(
                     append(HttpHeaders.UserAgent, userAgent)
                 }
             }
-        } catch (e: UnresolvedAddressException) {
-            Log.i(logTag, e.message.toString())
-            return Result.Error(DataError.Network.NoInternet)
-        } catch (_: HttpRequestTimeoutException) {
-            return Result.Error(DataError.Network.RequestTimeout)
-        } catch (_: SocketException) {
-            return Result.Error(DataError.Network.Unknown)
+        } catch (e: CancellationException) {
+            // Coroutine cancellation must propagate; never swallow.
+            throw e
+        } catch (e: Throwable) {
+            return Result.Error(e.toNetworkError())
         }
 
         when (response.status) {
@@ -74,8 +78,15 @@ class MusicBrainzMetadataProvider(
                     return Result.Success(
                         data = searchResult.toMetadataSearchResultList()
                     )
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: JsonConvertException) {
                     Log.d(logTag, e.message, e)
+                    return Result.Error(DataError.Network.ParseError)
+                } catch (e: Throwable) {
+                    // Defensive — body parsing can throw a wide range of
+                    // wrapped Ktor / kotlinx.serialization exceptions.
+                    Log.w(logTag, "Failed to parse MusicBrainz search response", e)
                     return Result.Error(DataError.Network.ParseError)
                 }
             }
@@ -129,11 +140,10 @@ class MusicBrainzMetadataProvider(
                     append(HttpHeaders.UserAgent, userAgent)
                 }
             }
-        } catch (e: UnresolvedAddressException) {
-            Log.d(logTag, e.message.toString())
-            return Result.Error(DataError.Network.NoInternet)
-        } catch (_: HttpRequestTimeoutException) {
-            return Result.Error(DataError.Network.RequestTimeout)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            return Result.Error(e.toNetworkError())
         }
 
         when (response.status) {
@@ -141,15 +151,20 @@ class MusicBrainzMetadataProvider(
                 try {
                     val bytes = response.body<ByteArray>()
                     return Result.Success(bytes)
-                } catch (e: Exception) {
-                    Log.d(logTag, e.message, e)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    Log.w(logTag, "Failed to read cover-art body", e)
                     return Result.Error(DataError.Network.ParseError)
                 }
             }
 
             HttpStatusCode.TemporaryRedirect -> {
+                // Ktor's default config follows redirects automatically, so
+                // we shouldn't see this in practice. Log + treat as unknown
+                // so future regressions in redirect handling surface clearly.
+                Log.d(logTag, "Unexpected 307 from CoverArtArchive: ${response.bodyAsText()}")
                 return Result.Error(DataError.Network.Unknown)
-                Log.d(logTag, "Redirected: ${response.bodyAsText()}")
             }
 
             HttpStatusCode.BadRequest -> {
@@ -165,6 +180,39 @@ class MusicBrainzMetadataProvider(
             }
 
             else -> return Result.Error(DataError.Network.Unknown)
+        }
+    }
+
+    /**
+     * Maps any thrown network-side exception onto our [DataError.Network]
+     * vocabulary. The previous code only caught a handful of exception
+     * types; everything else escaped and crashed the process. This is the
+     * single fallback so [searchMetadata] and [getCoverArtBytes] stay
+     * consistent and complete.
+     */
+    private fun Throwable.toNetworkError(): DataError.Network {
+        return when (this) {
+            is UnresolvedAddressException, is UnknownHostException -> {
+                Log.i(logTag, "DNS / address resolution failed: $message")
+                DataError.Network.NoInternet
+            }
+            is HttpRequestTimeoutException,
+            is ConnectTimeoutException,
+            is SocketTimeoutException -> {
+                DataError.Network.RequestTimeout
+            }
+            is SSLException -> {
+                Log.w(logTag, "TLS handshake / cert error: $message")
+                DataError.Network.Unknown
+            }
+            is SocketException, is IOException -> {
+                Log.w(logTag, "Network I/O error: $message")
+                DataError.Network.Unknown
+            }
+            else -> {
+                Log.w(logTag, "Unexpected network failure", this)
+                DataError.Network.Unknown
+            }
         }
     }
 }

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -56,7 +56,13 @@ val playerModule = module {
                 )
             }
             install(HttpTimeout) {
-                requestTimeoutMillis = 180000
+                // Snappy enough that a flaky network produces a user-visible
+                // error inside the attention span of someone who just tapped
+                // "Search" — the previous 3-minute total was effectively
+                // "the app is hung".
+                requestTimeoutMillis = 20_000
+                connectTimeoutMillis = 10_000
+                socketTimeoutMillis = 15_000
             }
         }
     }


### PR DESCRIPTION
## What's in v1.3.5

Phase 4, **item 2 of 3**. Stability fix for the metadata search crash you reported. Per your directive, I evaluated whether the feature is useful first.

**Decision: keep + fix.** MusicBrainz lookup is genuinely useful for fixing badly-tagged music — removing it would be a regression. The crash was just incomplete exception handling.

**Layman:** Searching online for track metadata (Track info → Search) and fetching lyrics from LRCLIB used to crash the app on flaky networks — DNS hiccups, TLS / certificate weirdness, slow connections. Now those failures pop a snackbar with a helpful message instead of taking the app down. Bonus: the request timeout dropped from **3 minutes** to **20 seconds**, so a slow lookup gives you an error long before you'd reach for the back button.

---

## Technical

### Three concrete bugs found

1. **Narrow exception catches** in both providers. They handled `UnresolvedAddressException`, `HttpRequestTimeoutException`, and (sometimes) `SocketException`. Real-world failures escape this net:
   - `ConnectTimeoutException`, `SocketTimeoutException` (distinct from `HttpRequestTimeoutException`)
   - `UnknownHostException` (DNS failures on some Android stacks)
   - `SSLException` (TLS handshake / cert errors)
   - Generic `IOException` and friends
2. **3-minute total timeout** in `PlayerModule.kt` — `requestTimeoutMillis = 180_000`. User stares at a spinner for that long before getting an error.
3. **Dead code** in `MusicBrainzMetadataProvider.getCoverArtBytes`: a `Log.d(...)` line *after* a `return` — unreachable.

### Fix — single classifier, broad fallback

Both providers now share the pattern:

```kotlin
} catch (e: CancellationException) {
    throw e   // structured concurrency intact
} catch (e: Throwable) {
    return Result.Error(e.toNetworkError())
}
```

Where each provider has a `private fun Throwable.toNetworkError()` that classifies into the existing `DataError.Network` enum (`NoInternet`, `RequestTimeout`, `ParseError`, `Unknown`) with logging. `CancellationException` is explicitly re-thrown so coroutine cancellation still unwinds correctly — never swallow it.

### Files touched

| File | What changed |
| --- | --- |
| `MusicBrainzMetadataProvider.kt` | Both `searchMetadata` + `getCoverArtBytes` now use `Throwable.toNetworkError()`. Body-parse paths gain matching fallback. Dead-code `Log.d` moved before the redirect `return`. |
| `LrclibLyricsProvider.kt` | All three network call sites (`getLyrics`, `postLyrics` request-challenge, `postLyrics` publish) use the same pattern. Stray `println("RESPONSE BODY: ...")` from earlier debugging replaced with `Log.d(logTag, ...)`. |
| `PlayerModule.kt` | `requestTimeoutMillis 180_000 → 20_000`, plus new `connectTimeoutMillis = 10_000` and `socketTimeoutMillis = 15_000`. |

### Version

- `versionCode 1_003_004 → 1_003_005`
- `versionName 1.3.4-community → 1.3.5-community`

## Test plan

- [ ] Track info → Search a real song → results come back as before (happy path unchanged)
- [ ] Toggle airplane mode → tap Search → "no internet" snackbar, no crash
- [ ] Network with high latency / packet loss (or a captive-portal Wi-Fi) → "timeout" snackbar within ~20s, no 3-minute hang
- [ ] Pick a metadata search result with cover art → cover art downloads
- [ ] Pick a result whose CoverArtArchive URL fails → graceful error toast, no crash
- [ ] Fetch lyrics from LRCLIB on a normal network → succeeds (sanity check that I didn't break the happy path)
- [ ] Fetch lyrics with airplane mode → "no internet" snackbar
- [ ] Publish lyrics with airplane mode → "no internet" snackbar (postLyrics path)
- [ ] After merge + tag `v1.3.5`: CHANGELOG-driven release notes, all five APKs ship

---

## Phase 4 roadmap status

- ✅ #1 — Notification fix (v1.3.4)
- ✅ #2 — Metadata-search crash (this PR, v1.3.5)
- ⏳ #3 — F-droid + itch.io distribution docs (v1.3.6 — pure docs PR)

https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLFirSrez9Bt4XcJstpNSp)_