### PR TITLE
fix(queue): play-next reorder + shuffle-mode handling (v1.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.3.6 — Fix "Play next" + queue handling in shuffle mode
+
+**Layman:** Two related queue bugs. Tapping "Play next" on a track
+already in the queue moved it to the wrong position (right *before*
+the currently-playing track instead of after). And in shuffle mode,
+"Play next" didn't actually play the track next — it inserted the
+track at a random position in the shuffle order, so it would play at
+some unpredictable later time. Fixed: the move math is correct now,
+and tapping "Play next" while shuffle is on switches to the
+non-shuffle Repeat mode (with a snackbar) so the track reliably plays
+next. Re-enable shuffle from the playback-mode toggle when you want
+it back.
+
+**Technical:**
+- `OnPlayNextClick` reorder branch (track already in queue): the
+  destination index passed to `OnReorderingQueue` was always
+  `currentTrackIndex`. Media3's `moveMediaItem(from, newIndex)` places
+  the item at `newIndex` post-move; for a track at index 5 moved to
+  index 3, the previously-current item shifts to index 4, so the
+  moved track ends up *before* the current one. Fixed by computing
+  destination conditionally:
+  - `trackIndex > currentTrackIndex` → `currentTrackIndex + 1`
+  - `trackIndex < currentTrackIndex` → `currentTrackIndex` (current
+    shifts down by 1 when target is removed; landing target at this
+    index puts it right after the new current position)
+- `OnPlayNextClick` add-new branch (track not yet in queue): in
+  shuffle mode `Player.addMediaItem(currentMediaItemIndex + 1, item)`
+  inserts at the timeline position, but Media3's
+  `DefaultShuffleOrder.cloneAndInsert` places the new item at a
+  random position in the shuffle order, defeating "play next" intent.
+  Workaround: detect shuffle, switch playback mode to Repeat, persist
+  via `savedPlayerState.playbackMode`, then add at `currentIndex + 1`
+  as before. Snackbar `R.string.shuffle_disabled_for_play_next`
+  (localised EN/RU/UK) explains the change.
+- `OnAddToQueueClick` left alone — appending to the timeline + random
+  shuffle position is consistent with what users mean by "add to
+  queue" (the order is already random by design).
+
 ## 1.3.5 — Stop crashes during MusicBrainz / LRCLIB requests
 
 **Layman:** Searching online for track metadata (the "Track info →

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_003_005
-        versionName = "1.3.5-community"
+        versionCode = 1_003_006
+        versionName = "1.3.6-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
@@ -572,6 +572,25 @@ class PlayerViewModel(
             is OnPlayNextClick -> {
                 if (_playbackState.value.currentTrack == event.track) return
 
+                // Media3's DefaultShuffleOrder.cloneAndInsert places newly-
+                // added items at a random position in the shuffle order, so
+                // an inserted "play next" track plays at some random later
+                // time instead of next. Switch to Repeat so the user gets
+                // the behaviour they tapped for; they can re-shuffle from
+                // the playback-mode toggle afterwards.
+                val shuffleWasOn =
+                    _playbackState.value.playbackMode == PlaybackMode.Shuffle
+                if (shuffleWasOn) {
+                    setPlayerPlaybackMode(PlaybackMode.Repeat)
+                    _playbackState.update { it.copy(playbackMode = PlaybackMode.Repeat) }
+                    savedPlayerState.playbackMode = PlaybackMode.Repeat
+                    viewModelScope.launch {
+                        SnackbarController.sendEvent(
+                            SnackbarEvent(message = R.string.shuffle_disabled_for_play_next)
+                        )
+                    }
+                }
+
                 _playbackState.value.playlist?.let { playlist ->
                     val trackIndex = playlist.trackList.indexOf(event.track)
                     val currentTrackIndex = _playbackState.value.currentTrack?.let {
@@ -579,10 +598,24 @@ class PlayerViewModel(
                     } ?: 0
 
                     if (trackIndex >= 0) {
+                        // Media3's moveMediaItem(from, newIndex) places the
+                        // moved item AT newIndex post-move. To land the
+                        // track immediately after the current one:
+                        //   trackIndex > current: removing from a later
+                        //     index doesn't shift current, so destination
+                        //     is currentTrackIndex + 1.
+                        //   trackIndex < current: removing from an earlier
+                        //     index shifts current down by 1, so destination
+                        //     is currentTrackIndex (= newCurrent + 1).
+                        val destinationIndex = if (trackIndex < currentTrackIndex) {
+                            currentTrackIndex
+                        } else {
+                            currentTrackIndex + 1
+                        }
                         onEvent(
                             OnReorderingQueue(
                                 trackIndex,
-                                (currentTrackIndex).coerceAtMost(playlist.trackList.lastIndex)
+                                destinationIndex.coerceAtMost(playlist.trackList.lastIndex)
                             )
                         )
                         return

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -200,6 +200,9 @@
     <string name="cant_find_lyrics">Текст не найден.</string>
     <string name="lyrics_provided_by">Текст предоставлен LRCLIB</string>
 
+    <!-- Playback queue -->
+    <string name="shuffle_disabled_for_play_next">Перемешивание выключено: этот трек воспроизведётся следующим</string>
+
     <!-- Playlists related -->
     <string name="create_playlist">Создать плейлист</string>
     <string name="add_to_playlist">Добавить в плейлист</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -200,6 +200,9 @@
     <string name="cant_find_lyrics">Текст не знайдено.</string>
     <string name="lyrics_provided_by">Текст наданий LRCLIB</string>
 
+    <!-- Playback queue -->
+    <string name="shuffle_disabled_for_play_next">Перемішування вимкнено: цей трек відтвориться наступним</string>
+
     <!-- Playlists related -->
     <string name="create_playlist">Створити плейлист</string>
     <string name="add_to_playlist">Додати до плейлисту</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,6 +212,9 @@
     <string name="cant_find_lyrics">Can\'t find lyrics.</string>
     <string name="lyrics_provided_by">Lyrics provided by LRCLIB</string>
 
+    <!-- Playback queue -->
+    <string name="shuffle_disabled_for_play_next">Shuffle turned off so this track plays next</string>
+
     <!-- Playlists related -->
     <string name="create_playlist">Create playlist</string>
     <string name="add_to_playlist">Add to playlist</string>


### PR DESCRIPTION
## v1.3.6 — Two queue bugs fixed

**Layman:** Two related problems with "Play next" — the move math was wrong (track was landing right *before* the current song instead of after), and in shuffle mode the inserted track played at a random later time instead of next. Fixed.

**Technical:**

### Bug 1 — `OnPlayNextClick` reorder off-by-one

Track already in queue → `OnReorderingQueue(trackIndex, currentTrackIndex)`. Media3's `moveMediaItem(from, newIndex)` places the moved item AT `newIndex` post-move. For `trackIndex > currentIndex`, the previously-current track shifts to `currentIndex + 1`, so the moved track landed **before** the current one.

Fix:
- `trackIndex > currentTrackIndex` → destination = `currentTrackIndex + 1`
- `trackIndex < currentTrackIndex` → destination = `currentTrackIndex` (target removal shifts current down by 1, so this lands right after new-current)

### Bug 2 — `OnPlayNextClick` shuffle mode

`Player.addMediaItem(currentIndex + 1, item)` inserts at the timeline index, but Media3's `DefaultShuffleOrder.cloneAndInsert` places the new index at a **random** position in the shuffle order. The track plays at some unpredictable later time, not next.

Fix: detect shuffle, switch playback mode to Repeat (also persisting via `savedPlayerState.playbackMode`), then add at `currentIndex + 1` as before. New snackbar `R.string.shuffle_disabled_for_play_next` (EN/RU/UK) explains the toggle. User can re-enable shuffle from the playback-mode button.

### Out of scope

`OnAddToQueueClick` (Add to Queue) left unchanged. Appending + shuffle = random order is consistent with what "add to queue" means in shuffle mode.

### Version

- `versionCode 1_003_005 → 1_003_006`
- `versionName 1.3.5-community → 1.3.6-community`

## Test plan

- [ ] Non-shuffle: tap "Play next" on a track later in the queue → it plays right after current
- [ ] Non-shuffle: tap "Play next" on a track earlier in the queue → it plays right after current (previously broken)
- [ ] Non-shuffle: tap "Play next" on a brand-new track → added right after current
- [ ] Shuffle on: tap "Play next" on any track → snackbar shows "Shuffle turned off…", playback mode switches to Repeat, the track plays next
- [ ] Re-enable shuffle from the playback-mode button → shuffle works as before
- [ ] Add to queue (no Play-next): unchanged behaviour
- [ ] Tag `v1.3.6` after merge: release CI builds + ships APKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)