### PR TITLE
feat(lyrics): NetEase backup + cache short-circuit (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.4.0 — NetEase as a lyrics backup, plus a cache fix
+
+If LRCLIB doesn't have the lyrics you're looking for, the app now
+asks NetEase Cloud Music as a fallback. NetEase has a much wider
+catalogue (especially for Asian and indie pop), so the "lyrics not
+found" snackbar should show up a lot less often. The fallback is on
+by default and there's a switch in Settings → Lyrics if you'd rather
+keep things LRCLIB-only.
+
+There's also a small but slightly embarrassing fix: when you opened
+a track you'd already pulled lyrics for, the app was hitting the
+network anyway and only checking the local cache as a side effect of
+the view model. The cache lookup now lives where it should — inside
+the lyrics fetcher itself — so cached lyrics show instantly and the
+re-fetch button still bypasses the cache the way you'd expect.
+
+A couple of things worth knowing:
+
+- NetEase is a Chinese service; the request goes to music.163.com
+  and includes the track title and artist (no other metadata). If
+  that's not OK for your threat model, flip the switch off.
+- NetEase doesn't accept lyric submissions, so the "publish to
+  remote" button still goes to LRCLIB only.
+- The `lyrics_not_found` message no longer says "on LRCLIB" since
+  it now means "we tried every source you've enabled and nothing
+  matched".
+
+Under the hood: `ChainLyricsProvider` composes an ordered list of
+sources and returns the first hit. NetEase is wrapped in a
+`GatedLyricsProvider` that consults the settings flag at call time,
+so toggling the switch takes effect without an app restart. The
+shared `Throwable.toNetworkError()` mapping moved out of LRCLIB into
+its own file because both providers need it.
+
 ## 1.3.6 — Fix "Play next" + queue handling in shuffle mode
 
 **Layman:** Two related queue bugs. Tapping "Play next" on a track

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_003_006
-        versionName = "1.3.6-community"
+        versionCode = 1_004_000
+        versionName = "1.4.0-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/ChainLyricsProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/ChainLyricsProvider.kt
@@ -1,0 +1,43 @@
+package com.dn0ne.player.app.data.remote.lyrics
+
+import com.dn0ne.player.app.domain.lyrics.Lyrics
+import com.dn0ne.player.app.domain.result.DataError
+import com.dn0ne.player.app.domain.result.Result
+import com.dn0ne.player.app.domain.track.Track
+
+// Tries each provider in order. The first one to find lyrics wins; a NotFound
+// from any provider falls through to the next. BadRequest is a property of the
+// query (e.g. missing title), not of the source — short-circuit it. The post
+// path delegates to the first provider in the list, which is the LRCLIB one
+// because that's the only source we can publish to.
+class ChainLyricsProvider(
+    private val providers: List<LyricsProvider>,
+) : LyricsProvider {
+
+    init {
+        require(providers.isNotEmpty()) { "ChainLyricsProvider needs at least one provider" }
+    }
+
+    override suspend fun getLyrics(track: Track): Result<Lyrics, DataError.Network> {
+        var lastError: DataError.Network = DataError.Network.NotFound
+
+        for (provider in providers) {
+            when (val result = provider.getLyrics(track)) {
+                is Result.Success -> return result
+                is Result.Error -> {
+                    if (result.error == DataError.Network.BadRequest) {
+                        return result
+                    }
+                    lastError = result.error
+                }
+            }
+        }
+
+        return Result.Error(lastError)
+    }
+
+    override suspend fun postLyrics(
+        track: Track,
+        lyrics: Lyrics,
+    ): Result<Unit, DataError.Network> = providers.first().postLyrics(track, lyrics)
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/GatedLyricsProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/GatedLyricsProvider.kt
@@ -1,0 +1,22 @@
+package com.dn0ne.player.app.data.remote.lyrics
+
+import com.dn0ne.player.app.domain.lyrics.Lyrics
+import com.dn0ne.player.app.domain.result.DataError
+import com.dn0ne.player.app.domain.result.Result
+import com.dn0ne.player.app.domain.track.Track
+
+// Tiny wrapper that lets a chain skip a provider at runtime based on a
+// settings flag. Disabled providers report NotFound so the chain falls
+// through to the next entry instead of treating the disable as an error.
+class GatedLyricsProvider(
+    private val delegate: LyricsProvider,
+    private val isEnabled: () -> Boolean,
+) : LyricsProvider {
+    override suspend fun getLyrics(track: Track): Result<Lyrics, DataError.Network> =
+        if (isEnabled()) delegate.getLyrics(track) else Result.Error(DataError.Network.NotFound)
+
+    override suspend fun postLyrics(
+        track: Track,
+        lyrics: Lyrics,
+    ): Result<Unit, DataError.Network> = delegate.postLyrics(track, lyrics)
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/LrclibLyricsProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/LrclibLyricsProvider.kt
@@ -14,9 +14,6 @@ import com.dn0ne.player.app.presentation.components.snackbar.SnackbarEvent
 import com.dn0ne.player.core.util.getAppVersionName
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.network.sockets.ConnectTimeoutException
-import io.ktor.client.network.sockets.SocketTimeoutException
-import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -30,12 +27,7 @@ import io.ktor.http.headers
 import io.ktor.serialization.JsonConvertException
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
-import java.io.IOException
-import java.net.SocketException
-import java.net.UnknownHostException
-import java.nio.channels.UnresolvedAddressException
 import java.security.MessageDigest
-import javax.net.ssl.SSLException
 
 class LrclibLyricsProvider(
     context: Context,
@@ -72,7 +64,7 @@ class LrclibLyricsProvider(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            return Result.Error(e.toNetworkError())
+            return Result.Error(e.toNetworkError(logTag))
         }
 
         when (response.status) {
@@ -140,7 +132,7 @@ class LrclibLyricsProvider(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            return Result.Error(e.toNetworkError())
+            return Result.Error(e.toNetworkError(logTag))
         }
 
         if (response.status != HttpStatusCode.OK) return Result.Error(DataError.Network.Unknown)
@@ -187,7 +179,7 @@ class LrclibLyricsProvider(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            return Result.Error(e.toNetworkError())
+            return Result.Error(e.toNetworkError(logTag))
         }
 
         return if (response.status == HttpStatusCode.Created) {
@@ -195,38 +187,6 @@ class LrclibLyricsProvider(
         } else {
             Log.d(logTag, "Publish failed: ${response.status} ${response.bodyAsText()}")
             Result.Error(DataError.Network.Unknown)
-        }
-    }
-
-    /**
-     * Maps any thrown network-side exception onto our [DataError.Network]
-     * vocabulary. The previous code only caught a handful of types and
-     * everything else escaped, which is why a flaky-network "post lyrics"
-     * could crash the app.
-     */
-    private fun Throwable.toNetworkError(): DataError.Network {
-        return when (this) {
-            is UnresolvedAddressException, is UnknownHostException -> {
-                Log.i(logTag, "DNS / address resolution failed: $message")
-                DataError.Network.NoInternet
-            }
-            is HttpRequestTimeoutException,
-            is ConnectTimeoutException,
-            is SocketTimeoutException -> {
-                DataError.Network.RequestTimeout
-            }
-            is SSLException -> {
-                Log.w(logTag, "TLS handshake / cert error: $message")
-                DataError.Network.Unknown
-            }
-            is SocketException, is IOException -> {
-                Log.w(logTag, "Network I/O error: $message")
-                DataError.Network.Unknown
-            }
-            else -> {
-                Log.w(logTag, "Unexpected network failure", this)
-                DataError.Network.Unknown
-            }
         }
     }
 

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/NetEaseLyricsProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/NetEaseLyricsProvider.kt
@@ -1,0 +1,210 @@
+package com.dn0ne.player.app.data.remote.lyrics
+
+import android.util.Log
+import com.dn0ne.player.app.domain.lyrics.Lyrics
+import com.dn0ne.player.app.domain.lyrics.toSyncedLyrics
+import com.dn0ne.player.app.domain.result.DataError
+import com.dn0ne.player.app.domain.result.Result
+import com.dn0ne.player.app.domain.track.Track
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.JsonConvertException
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.math.abs
+
+// Backup lyrics source. NetEase has a wide catalogue (a lot of pop the LRCLIB
+// crowd doesn't bother with) and the search/lyric pair below is the same one
+// every other open-source music app on Android uses. The endpoints are
+// undocumented but stable for years; the Referer header is the one bit of
+// "looks like a browser" we have to send or the API returns 502.
+class NetEaseLyricsProvider(
+    private val client: HttpClient,
+) : LyricsProvider {
+    private val searchEndpoint = "https://music.163.com/api/search/get/web"
+    private val lyricEndpoint = "https://music.163.com/api/song/lyric"
+    private val logTag = "NetEaseLyricsProvider"
+
+    override suspend fun getLyrics(track: Track): Result<Lyrics, DataError.Network> {
+        if (track.title == null || track.artist == null) {
+            return Result.Error(DataError.Network.BadRequest)
+        }
+
+        val songIdResult = search(track) ?: return Result.Error(DataError.Network.NotFound)
+        val songId = when (songIdResult) {
+            is Result.Success -> songIdResult.data
+            is Result.Error -> return Result.Error(songIdResult.error)
+        }
+
+        return fetchLyric(songId, track)
+    }
+
+    // NetEase is read-only — there's no public publish endpoint, and we don't
+    // want to pretend otherwise.
+    override suspend fun postLyrics(
+        track: Track,
+        lyrics: Lyrics,
+    ): Result<Unit, DataError.Network> = Result.Error(DataError.Network.BadRequest)
+
+    private suspend fun search(track: Track): Result<Long, DataError.Network>? {
+        val query = "${track.artist} ${track.title}"
+        val response = try {
+            client.get(searchEndpoint) {
+                url {
+                    parameters.append("s", query)
+                    parameters.append("type", "1")
+                    parameters.append("limit", "10")
+                    parameters.append("offset", "0")
+                }
+                headers {
+                    append(HttpHeaders.Referrer, "https://music.163.com/")
+                    append(HttpHeaders.UserAgent, BROWSER_UA)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            return Result.Error(e.toNetworkError(logTag))
+        }
+
+        if (response.status != HttpStatusCode.OK) {
+            return Result.Error(DataError.Network.Unknown)
+        }
+
+        val dto = try {
+            response.body<SearchResponse>()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: JsonConvertException) {
+            Log.d(logTag, "Failed to parse NetEase search response", e)
+            return Result.Error(DataError.Network.ParseError)
+        } catch (e: Throwable) {
+            Log.w(logTag, "Failed to parse NetEase search response", e)
+            return Result.Error(DataError.Network.ParseError)
+        }
+
+        val songs = dto.result?.songs.orEmpty()
+        if (songs.isEmpty()) return null
+
+        val expectedDurationMs = track.duration
+        val pick = songs.minByOrNull { song ->
+            // Lower score = better match. Duration distance dominates; missing
+            // duration falls back to "first result", which is what the search
+            // endpoint already ranks by relevance.
+            val durationDelta = song.duration?.let { abs(it - expectedDurationMs) } ?: Int.MAX_VALUE
+            durationDelta
+        } ?: return null
+
+        return Result.Success(pick.id)
+    }
+
+    private suspend fun fetchLyric(
+        songId: Long,
+        track: Track,
+    ): Result<Lyrics, DataError.Network> {
+        val response = try {
+            client.get(lyricEndpoint) {
+                url {
+                    parameters.append("id", songId.toString())
+                    parameters.append("lv", "1")
+                    parameters.append("kv", "1")
+                    parameters.append("tv", "-1")
+                }
+                headers {
+                    append(HttpHeaders.Referrer, "https://music.163.com/")
+                    append(HttpHeaders.UserAgent, BROWSER_UA)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            return Result.Error(e.toNetworkError(logTag))
+        }
+
+        if (response.status != HttpStatusCode.OK) {
+            return Result.Error(DataError.Network.Unknown)
+        }
+
+        val dto = try {
+            response.body<LyricResponse>()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: JsonConvertException) {
+            Log.d(logTag, "Failed to parse NetEase lyric response", e)
+            return Result.Error(DataError.Network.ParseError)
+        } catch (e: Throwable) {
+            Log.w(logTag, "Failed to parse NetEase lyric response", e)
+            return Result.Error(DataError.Network.ParseError)
+        }
+
+        val raw = dto.lrc?.lyric?.takeIf { it.isNotBlank() }
+            ?: return Result.Error(DataError.Network.NotFound)
+
+        val syncedLines = try {
+            raw.toSyncedLyrics()
+        } catch (e: IllegalArgumentException) {
+            // No timestamps. Fall back to plain text — split on lines and
+            // strip any stray bracket-prefixed metadata ([ar:], [ti:], …).
+            null
+        }
+
+        val plainLines = raw.split('\n')
+            .map { line -> line.replace(LRC_LEADING_TAGS, "").trim() }
+            .filter { it.isNotEmpty() }
+
+        return Result.Success(
+            Lyrics(
+                uri = track.uri.toString(),
+                plain = plainLines.takeIf { it.isNotEmpty() },
+                synced = syncedLines,
+            )
+        )
+    }
+
+    @Serializable
+    private data class SearchResponse(
+        val result: SearchResult? = null,
+        val code: Int = 0,
+    )
+
+    @Serializable
+    private data class SearchResult(
+        val songs: List<SearchSong>? = null,
+    )
+
+    @Serializable
+    private data class SearchSong(
+        val id: Long,
+        val name: String? = null,
+        @SerialName("duration") val duration: Int? = null,
+    )
+
+    @Serializable
+    private data class LyricResponse(
+        val lrc: LyricBody? = null,
+        val code: Int = 0,
+    )
+
+    @Serializable
+    private data class LyricBody(
+        val lyric: String? = null,
+    )
+
+    private companion object {
+        // A plain "ktor-client" UA gets blocked by NetEase's edge. Any
+        // browser-shaped UA works; this one is generic and doesn't lie about
+        // a specific Chrome version that'll get stale.
+        const val BROWSER_UA =
+            "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Mobile"
+
+        // Strip every leading [mm:ss.xx] timestamp (lines can have several)
+        // and standalone metadata tags ([ar:], [ti:], [by:]) so the plain-text
+        // view doesn't leak them.
+        val LRC_LEADING_TAGS = Regex("""^(\[[^\]]+\])+""")
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/NetworkErrorMapping.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/lyrics/NetworkErrorMapping.kt
@@ -1,0 +1,38 @@
+package com.dn0ne.player.app.data.remote.lyrics
+
+import android.util.Log
+import com.dn0ne.player.app.domain.result.DataError
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import java.io.IOException
+import java.net.SocketException
+import java.net.UnknownHostException
+import java.nio.channels.UnresolvedAddressException
+import javax.net.ssl.SSLException
+
+internal fun Throwable.toNetworkError(logTag: String): DataError.Network {
+    return when (this) {
+        is UnresolvedAddressException, is UnknownHostException -> {
+            Log.i(logTag, "DNS / address resolution failed: $message")
+            DataError.Network.NoInternet
+        }
+        is HttpRequestTimeoutException,
+        is ConnectTimeoutException,
+        is SocketTimeoutException -> {
+            DataError.Network.RequestTimeout
+        }
+        is SSLException -> {
+            Log.w(logTag, "TLS handshake / cert error: $message")
+            DataError.Network.Unknown
+        }
+        is SocketException, is IOException -> {
+            Log.w(logTag, "Network I/O error: $message")
+            DataError.Network.Unknown
+        }
+        else -> {
+            Log.w(logTag, "Unexpected network failure", this)
+            DataError.Network.Unknown
+        }
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -10,8 +10,12 @@ import com.dn0ne.player.app.data.SavedPlayerState
 import com.dn0ne.player.app.data.db.LotusDatabase
 import com.dn0ne.player.app.data.db.LyricsDao
 import com.dn0ne.player.app.data.db.PlaylistDao
+import com.dn0ne.player.app.data.remote.lyrics.ChainLyricsProvider
+import com.dn0ne.player.app.data.remote.lyrics.GatedLyricsProvider
 import com.dn0ne.player.app.data.remote.lyrics.LrclibLyricsProvider
 import com.dn0ne.player.app.data.remote.lyrics.LyricsProvider
+import com.dn0ne.player.app.data.remote.lyrics.NetEaseLyricsProvider
+import com.dn0ne.player.core.data.Settings
 import com.dn0ne.player.app.data.remote.metadata.MetadataProvider
 import com.dn0ne.player.app.data.remote.metadata.MusicBrainzMetadataProvider
 import com.dn0ne.player.app.data.repository.LyricsRepository
@@ -79,10 +83,16 @@ val playerModule = module {
     }
 
     single<LyricsProvider> {
-        LrclibLyricsProvider(
+        val settings = get<Settings>()
+        val lrclib = LrclibLyricsProvider(
             context = androidContext(),
-            client = get()
+            client = get(),
         )
+        val netEase = GatedLyricsProvider(
+            delegate = NetEaseLyricsProvider(client = get()),
+            isEnabled = { settings.useNetEaseLyricsFallback },
+        )
+        ChainLyricsProvider(listOf(lrclib, netEase))
     }
 
     single<LotusDatabase> {

--- a/app/src/main/java/com/dn0ne/player/app/domain/lyrics/LyricsFetcher.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/lyrics/LyricsFetcher.kt
@@ -49,17 +49,25 @@ class LyricsFetcher(
         }
     }
 
-    /**
-     * Fetches lyrics from the configured remote provider (LRCLIB). Caches a
-     * successful result in the local repository. Network / parse errors
-     * surface as snackbars; no exception escapes.
-     */
-    suspend fun fetchFromRemote(track: Track): Lyrics? = withContext(Dispatchers.IO) {
+    // Returns lyrics for the track, hitting the local cache first and only
+    // calling the remote provider on a miss. Pass forceRemote = true when the
+    // user explicitly asks for a re-fetch (the lyrics-control sheet button) so
+    // we go around the cache and write the fresh copy back.
+    //
+    // Network / parse errors surface as snackbars; no exception escapes.
+    suspend fun fetchFromRemote(
+        track: Track,
+        forceRemote: Boolean = false,
+    ): Lyrics? = withContext(Dispatchers.IO) {
         if (track.title == null || track.artist == null) {
             SnackbarController.sendEvent(
                 SnackbarEvent(message = R.string.cant_look_for_lyrics_title_or_artist_is_missing)
             )
             return@withContext null
+        }
+
+        if (!forceRemote) {
+            lyricsRepository.getLyricsByUri(track.uri.toString())?.let { return@withContext it }
         }
 
         when (val result = lyricsProvider.getLyrics(track)) {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
@@ -1197,7 +1197,7 @@ class PlayerViewModel(
                             isFetchingFromRemote = true
                         )
                     }
-                    val lyrics = lyricsFetcher.fetchFromRemote(track)
+                    val lyrics = lyricsFetcher.fetchFromRemote(track, forceRemote = true)
 
                     _lyricsControlSheetState.update {
                         it.copy(
@@ -1398,8 +1398,7 @@ class PlayerViewModel(
                     )
                 }
 
-                var lyrics: Lyrics? = lyricsRepository.getLyricsByUri(currentTrack.uri.toString())
-                    ?: lyricsFetcher.fetchFromRemote(currentTrack)
+                var lyrics: Lyrics? = lyricsFetcher.fetchFromRemote(currentTrack)
                     ?: lyricsFetcher.readFromTag(currentTrack, viewModelScope)
                         ?.also { lyricsRepository.insertLyrics(it) }
 

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/LyricsSettings.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/LyricsSettings.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowBackIosNew
+import androidx.compose.material.icons.rounded.CloudDownload
 import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -106,6 +107,21 @@ fun LyricsSettings(
             onCheckedChange = {
                 settings.useDarkPaletteOnLyricsSheet = it
                 useDarkPaletteOnLyricsSheet = it
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        var useNetEaseLyricsFallback by remember {
+            mutableStateOf(settings.useNetEaseLyricsFallback)
+        }
+        SettingSwitch(
+            title = context.resources.getString(R.string.netease_fallback),
+            supportingText = context.resources.getString(R.string.netease_fallback_explain),
+            icon = Icons.Rounded.CloudDownload,
+            isChecked = useNetEaseLyricsFallback,
+            onCheckedChange = {
+                settings.useNetEaseLyricsFallback = it
+                useNetEaseLyricsFallback = it
             },
             modifier = Modifier.fillMaxWidth()
         )

--- a/app/src/main/java/com/dn0ne/player/core/data/Settings.kt
+++ b/app/src/main/java/com/dn0ne/player/core/data/Settings.kt
@@ -32,6 +32,7 @@ class Settings(context: Context) {
     private val lyricsLetterSpacingKey = "lyrics-letter-spacing"
     private val lyricsAlignmentKey = "lyrics-alignment"
     private val useDarkPaletteOnLyricsSheetKey = "dark-palette-on-lyrics-sheet"
+    private val useNetEaseLyricsFallbackKey = "use-netease-lyrics-fallback"
 
     private val areRisksOfMetadataEditingAcceptedKey = "metadata-editing-dialog"
 
@@ -215,6 +216,15 @@ class Settings(context: Context) {
         set(value) {
             with(sharedPreferences.edit()) {
                 putBoolean(useDarkPaletteOnLyricsSheetKey, value)
+                apply()
+            }
+        }
+
+    var useNetEaseLyricsFallback: Boolean
+        get() = sharedPreferences.getBoolean(useNetEaseLyricsFallbackKey, true)
+        set(value) {
+            with(sharedPreferences.edit()) {
+                putBoolean(useNetEaseLyricsFallbackKey, value)
                 apply()
             }
         }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -196,9 +196,11 @@
 
     <!-- Lyrics screen errors -->
     <string name="cant_look_for_lyrics_title_or_artist_is_missing">Не удается найти текст. Для этого трека не указано название или исполнитель.</string>
-    <string name="lyrics_not_found">К сожалению, на LRCLIB текст к этому треку найти не удалось.</string>
+    <string name="lyrics_not_found">К сожалению, текст к этому треку найти не удалось.</string>
     <string name="cant_find_lyrics">Текст не найден.</string>
     <string name="lyrics_provided_by">Текст предоставлен LRCLIB</string>
+    <string name="netease_fallback">Использовать NetEase как запасной источник</string>
+    <string name="netease_fallback_explain">Если на LRCLIB текста нет, попробовать NetEase Cloud Music. На music.163.com отправляются название трека и исполнитель.</string>
 
     <!-- Playback queue -->
     <string name="shuffle_disabled_for_play_next">Перемешивание выключено: этот трек воспроизведётся следующим</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -196,9 +196,11 @@
 
     <!-- Lyrics screen errors -->
     <string name="cant_look_for_lyrics_title_or_artist_is_missing">Не вдається знайти текст. Для цього треку не вказано назву або виконавця.</string>
-    <string name="lyrics_not_found">На жаль, на LRCLIB текст до цього треку знайти не вдалося.</string>
+    <string name="lyrics_not_found">На жаль, текст до цього треку знайти не вдалося.</string>
     <string name="cant_find_lyrics">Текст не знайдено.</string>
     <string name="lyrics_provided_by">Текст наданий LRCLIB</string>
+    <string name="netease_fallback">Використовувати NetEase як запасне джерело</string>
+    <string name="netease_fallback_explain">Якщо на LRCLIB тексту немає, спробувати NetEase Cloud Music. На music.163.com надсилаються назва треку та виконавець.</string>
 
     <!-- Playback queue -->
     <string name="shuffle_disabled_for_play_next">Перемішування вимкнено: цей трек відтвориться наступним</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,9 +208,11 @@
 
     <!-- Lyrics screen errors -->
     <string name="cant_look_for_lyrics_title_or_artist_is_missing">Can\'t look for lyrics. Title or artist is not specified for this track.</string>
-    <string name="lyrics_not_found">Unfortunately, lyrics for this track can\'t be found on LRCLIB.</string>
+    <string name="lyrics_not_found">Unfortunately, lyrics for this track can\'t be found.</string>
     <string name="cant_find_lyrics">Can\'t find lyrics.</string>
     <string name="lyrics_provided_by">Lyrics provided by LRCLIB</string>
+    <string name="netease_fallback">Use NetEase as a backup</string>
+    <string name="netease_fallback_explain">When LRCLIB has nothing, try NetEase Cloud Music. Sends the track\'s title and artist to music.163.com.</string>
 
     <!-- Playback queue -->
     <string name="shuffle_disabled_for_play_next">Shuffle turned off so this track plays next</string>


### PR DESCRIPTION
## What's in v1.4.0

LRCLIB has gaps. NetEase fills a lot of them, especially for Asian and indie pop. Adds a second lyrics source plus a cache fix that should have shipped a long time ago.

### NetEase as a fallback

`NetEaseLyricsProvider` searches `music.163.com` and pulls the LRC from `song/lyric`. Two requests per lookup (search → fetch by ID), but only when LRCLIB has nothing — the chain returns the first success.

`ChainLyricsProvider` composes the two sources. First `Result.Success` wins. `NotFound` from one falls through to the next. `BadRequest` (missing title/artist) short-circuits — no point asking two services the same broken question.

`GatedLyricsProvider` wraps NetEase with a `() -> Boolean` check against `Settings.useNetEaseLyricsFallback`, so flipping the toggle takes effect on the next lookup. No app restart, no DI rebuild.

NetEase is read-only. `postLyrics` returns `BadRequest`, so the chain's `postLyrics` (which delegates to the first provider, LRCLIB) is unaffected.

### Cache short-circuit

Before this PR, `PlayerViewModel.loadLyrics` did the cache check itself:

```kotlin
var lyrics: Lyrics? = lyricsRepository.getLyricsByUri(currentTrack.uri.toString())
    ?: lyricsFetcher.fetchFromRemote(currentTrack)
    ?: lyricsFetcher.readFromTag(currentTrack, viewModelScope)
        ?.also { lyricsRepository.insertLyrics(it) }
```

So the cache-first behaviour only happened for the auto-load path. Any other caller of `fetchFromRemote` (and any future caller of the chain) hits the network even with cached lyrics sitting in Room.

Cache lookup moved into `LyricsFetcher.fetchFromRemote`. Added a `forceRemote: Boolean = false` flag so the lyrics-control sheet's "re-fetch" button still bypasses the cache (`OnFetchLyricsFromRemoteClick` now passes `forceRemote = true`).

### Settings

New toggle under Settings → Lyrics: **Use NetEase as a backup**, default ON. Subtitle explains the request goes to `music.163.com` with title + artist only.

`lyrics_not_found` string updated — used to say "...can't be found on LRCLIB", now just "...can't be found", since multiple sources may have been tried.

### Cleanup

`Throwable.toNetworkError()` was inlined in `LrclibLyricsProvider`. Moved to `NetworkErrorMapping.kt` so NetEase reuses the exact same exception → `DataError.Network` mapping LRCLIB went through last release. No behaviour change for LRCLIB.

### F-Droid

`AntiFeatures: NonFreeNet` already covers this — same category as LRCLIB. The `docs/DISTRIBUTION.md` recipe doesn't need updating per release; the antifeature is already declared.

### Version

- `versionCode 1_003_006 → 1_004_000`
- `versionName 1.3.6-community → 1.4.0-community`

Minor bump because this is a new feature, not a bug fix.

## Test plan

- [ ] Settings → Lyrics → switch is ON by default
- [ ] Play a track with cached lyrics → lyrics appear instantly, no network spinner
- [ ] Play a track without cached lyrics that LRCLIB has → lyrics arrive via LRCLIB (snackbar attribution unchanged for now)
- [ ] Play a track LRCLIB doesn't have but NetEase does → lyrics arrive (no special UI, just no "not found" snackbar)
- [ ] Play a track neither service has → "Unfortunately, lyrics for this track can't be found." (no "on LRCLIB")
- [ ] Track-info → Lyrics control → re-fetch button → snackbar/loading spinner appears (cache bypassed) and lyrics refresh
- [ ] Toggle NetEase OFF → re-test "LRCLIB has nothing" track → "not found" snackbar (no NetEase attempt)
- [ ] Network off → snackbar "Looks like you're offline." (DNS error mapped via shared `toNetworkError`)
- [ ] After merge + tag `v1.4.0`: CHANGELOG-driven release notes, all five APKs ship