### PR TITLE
ci: Gradle wrapper validation + CodeQL weekly scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly, Monday 06:17 UTC. Off-peak slot to avoid the top-of-hour rush
+    # on GitHub-hosted runners.
+    - cron: "17 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (kotlin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          # Default queries are fine; security-extended adds a few more passes
+          # that are worth the extra minutes for an Android app.
+          queries: security-extended
+
+      - name: Build (autobuild fails on Android, so use Gradle directly)
+        run: |
+          chmod +x ./gradlew
+          ./gradlew assembleDebug --stacktrace
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java-kotlin"


### PR DESCRIPTION
## What's in this PR

Two small additions to the CI surface, neither of which changes the APK. No version bump.

### Gradle wrapper validation

One step added to `ci.yml`, near the top of the build job:

```yaml
- name: Validate Gradle wrapper
  uses: gradle/actions/wrapper-validation@v4
```

Catches a tampered `gradle-wrapper.jar` — the supply-chain attack vector that has bitten a number of Android projects (a malicious wrapper can run arbitrary code at build time on every contributor's machine and on CI). Free protection, runs in seconds.

### CodeQL weekly scan

New `.github/workflows/codeql.yml`. Runs on every push to master, on every PR, and weekly on a Monday-morning cron. Uses the `security-extended` query pack — for a small Android app the extra analysis time is in the noise, and it catches a few more patterns than the default suite.

Build step is explicit Gradle (`./gradlew assembleDebug`) rather than CodeQL's autobuild, which doesn't reliably handle the Android Gradle Plugin.

Findings will surface in the repo's **Security → Code scanning** tab once CodeQL is enabled in repo Settings → Code security → CodeQL analysis. That enable step is one-time and free for public repos.

### Why now

Both pieces are part of the "automated stability" push. They run on a schedule without anyone needing to remember to trigger them, and they fail loudly when something's wrong rather than quietly. Same spirit as Renovate (next PR) and the nightly build (PR after that).

## Test plan

- [ ] CI on this PR shows the new "Validate Gradle wrapper" step in the build job and it passes
- [ ] CodeQL workflow appears under Actions → CodeQL and runs on this PR
- [ ] After merge: enable CodeQL in repo Settings (one-time)
- [ ] Confirm the Monday-morning schedule fires the next week (any findings show in Security → Code scanning)