### PR TITLE
chore: add Renovate config (auto-merge off for now)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommitTypeAll(deps)"
+  ],
+  "schedule": [
+    "before 6am on Monday"
+  ],
+  "timezone": "UTC",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 0,
+  "rangeStrategy": "bump",
+  "labels": [
+    "dependencies"
+  ],
+  "platformAutomerge": false,
+  "automerge": false,
+  "dependencyDashboardTitle": "Renovate dashboard",
+  "packageRules": [
+    {
+      "description": "Group all Compose UI libraries with the BOM. Compose pieces have to move together or compose-compiler / runtime version mismatches will surface at runtime.",
+      "matchPackageNames": [
+        "androidx.compose:compose-bom",
+        "androidx.compose.ui:**",
+        "androidx.compose.material:**",
+        "androidx.compose.material3:**",
+        "androidx.compose.foundation:**",
+        "androidx.compose.runtime:**",
+        "androidx.compose.animation:**",
+        "androidx.activity:activity-compose",
+        "androidx.navigation:navigation-compose"
+      ],
+      "groupName": "compose",
+      "groupSlug": "compose"
+    },
+    {
+      "description": "Group all Media3 modules. They share a version and have to move together.",
+      "matchPackageNames": [
+        "androidx.media3:**"
+      ],
+      "groupName": "media3",
+      "groupSlug": "media3"
+    },
+    {
+      "description": "Group Room runtime/ktx/compiler/testing. Same coupling as media3.",
+      "matchPackageNames": [
+        "androidx.room:**"
+      ],
+      "groupName": "room",
+      "groupSlug": "room"
+    },
+    {
+      "description": "Group Ktor client + serialization modules. They share a version.",
+      "matchPackageNames": [
+        "io.ktor:**"
+      ],
+      "groupName": "ktor",
+      "groupSlug": "ktor"
+    },
+    {
+      "description": "Group Koin BOM and the modules that read it. BOM-managed versions need to stay in sync.",
+      "matchPackageNames": [
+        "io.insert-koin:**"
+      ],
+      "groupName": "koin",
+      "groupSlug": "koin"
+    },
+    {
+      "description": "AGP and Kotlin move together. Kotlin major/minor changes usually require an AGP bump and vice versa; bundling avoids two PRs that have to land in lockstep.",
+      "matchPackageNames": [
+        "com.android.application",
+        "com.android.library",
+        "com.android.tools.build:gradle",
+        "org.jetbrains.kotlin:**",
+        "org.jetbrains.kotlin.android",
+        "org.jetbrains.kotlin.plugin.compose",
+        "org.jetbrains.kotlin.plugin.serialization"
+      ],
+      "groupName": "agp + kotlin",
+      "groupSlug": "agp-kotlin"
+    },
+    {
+      "description": "KSP versions are pinned to a specific Kotlin version (e.g. 2.0.20-1.0.25). Group with the kotlin/agp PR so the two land together — KSP without a matching kotlin will fail to load.",
+      "matchPackageNames": [
+        "com.google.devtools.ksp",
+        "com.google.devtools.ksp:**"
+      ],
+      "groupName": "agp + kotlin",
+      "groupSlug": "agp-kotlin"
+    },
+    {
+      "description": "Detekt and ktlint can move on their own — they're CI-only and breakage is loud.",
+      "matchPackageNames": [
+        "io.gitlab.arturbosch.detekt",
+        "org.jlleitschuh.gradle.ktlint"
+      ],
+      "groupName": "static analysis",
+      "groupSlug": "static-analysis"
+    },
+    {
+      "description": "GitHub Actions used in workflows. One PR per week for any pinned-version action bumps.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Major version bumps always need a human look. Never auto-merge them even after we flip patches on.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "labels": [
+        "dependencies",
+        "major-update"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security",
+      "dependencies"
+    ]
+  },
+  "lockFileMaintenance": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## What's in this PR

A `renovate.json` at the repo root. No code changes, no version bump.

### What Renovate will do once installed

- Scan weekly, Monday before 6am UTC
- Open grouped dependency-update PRs
- Read `libs.versions.toml` directly (the version refs you already have keep working)
- Maintain a single rolling "Renovate dashboard" issue summarising pending work, instead of leaving you with a long list of individual PRs

### Grouping

Related dependencies are bundled into a single PR so they land together:

| Group | What's in it |
| --- | --- |
| `compose` | BOM + `androidx.compose.*` + `activity-compose` + `navigation-compose` |
| `media3` | All `androidx.media3.*` (shared version) |
| `room` | runtime / ktx / compiler / testing |
| `ktor` | client + serialization modules |
| `koin` | BOM + modules that read it |
| `agp + kotlin` | AGP + Kotlin + KSP bundled together (KSP pins to a Kotlin version; AGP and Kotlin usually need to move in lockstep) |
| `static analysis` | detekt + ktlint (CI-only, can move freely) |
| `github-actions` | Pinned action versions in `.github/workflows/` |

### Auto-merge: off everywhere for now

The intent is to watch for two weeks, see what Renovate actually proposes (and whether anything breaks subtly), then flip patch-level updates to auto-merge once the strict-lint gate from Phase 3 #4 is in place. Major bumps stay manual forever — anything labelled `major-update` won't auto-merge regardless.

### Activating Renovate

This config does nothing until the Renovate GitHub App is installed on the repo. It's free for open source: https://github.com/apps/renovate. One-click install. Once installed, Renovate will pick up `renovate.json` on the next scan.

### Vulnerability alerts

`vulnerabilityAlerts.enabled = true` so any GHSA advisory affecting a dependency opens a labelled PR right away (not on the weekly schedule).

## Test plan

- [ ] Merge this PR
- [ ] Install Renovate from https://github.com/apps/renovate (one-click, repo-scoped)
- [ ] Within a few hours, Renovate opens an onboarding PR (it confirms it can read the config) and creates the dashboard issue
- [ ] First Monday after merge: scheduled run opens grouped dependency PRs (or "no updates needed" comment on the dashboard)
- [ ] Spot-check a couple of grouped PRs to confirm they include the right packages