### PR TITLE
ci: nightly build + stale-bot

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,96 @@
+name: Nightly build
+
+on:
+  schedule:
+    # Tuesday 04:23 UTC. Picked off-peak and off-cycle from the Monday
+    # Renovate run so the two don't fight for runner time.
+    - cron: "23 4 * * 2"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & test on latest toolchain
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Unit tests
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: Assemble release APK
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Android lint (release)
+        run: ./gradlew lintRelease --stacktrace
+
+      - name: Open issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Reuse a single rolling issue rather than spamming the tracker
+          # every Tuesday a regression slips in. Close + reopen logic happens
+          # naturally — if the next nightly passes, the issue stays as-is and
+          # the maintainer can close it manually once they've fixed things.
+          existing=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --label "nightly-failure" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          body=$(cat <<MSG
+          The weekly nightly build failed.
+
+          Run: $RUN_URL
+
+          This is the scheduled build that runs every Tuesday morning
+          against the latest toolchain. A failure here usually means
+          one of:
+
+          - A new Android SDK / Gradle / Kotlin version surfaced a
+            regression (check the lint or compiler output in the run)
+          - A dependency update merged in the meantime broke something
+            (cross-reference recent Renovate PRs)
+          - A flake — re-run the workflow once to rule it out
+
+          Workflow file: .github/workflows/nightly.yml
+          MSG
+          )
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Nightly build failed" \
+              --label "nightly-failure" \
+              --body "$body"
+          fi

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,66 @@
+name: Stale
+
+on:
+  schedule:
+    # Daily at 03:11 UTC. Cheap workflow, runs in seconds.
+    - cron: "11 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues
+          days-before-issue-stale: 30
+          days-before-issue-close: 30
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been quiet for 30 days. If it's still
+            relevant, drop a comment and we'll keep it open. Otherwise
+            it'll close in 30 days. Thanks for the report.
+          close-issue-message: >
+            Closing for now since this hasn't seen activity in two
+            months. If it crops up again, please reopen — that's not
+            a refusal to look at it, just inbox hygiene.
+          exempt-issue-labels: >
+            pinned,
+            bug,
+            security,
+            help wanted,
+            good first issue,
+            confirmed,
+            nightly-failure
+
+          # Pull requests — more lenient, since contributors may need
+          # time to come back to a draft
+          days-before-pr-stale: 60
+          days-before-pr-close: 30
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has been quiet for two months. If you're still
+            working on it, no rush — drop a comment to keep it open.
+            Otherwise it'll close in 30 days; you can always reopen.
+          close-pr-message: >
+            Closing for inbox hygiene. Reopen any time if you'd like
+            to pick this back up.
+          exempt-pr-labels: >
+            pinned,
+            wip,
+            blocked
+
+          # Don't touch issues / PRs that have an assignee or a
+          # milestone — someone has actively claimed them.
+          exempt-all-assignees: true
+          exempt-all-milestones: true
+
+          # Process up to 100 items per run. Plenty for this repo's
+          # current volume; the action defaults are way too low.
+          operations-per-run: 100


### PR DESCRIPTION
## What's in this PR

Two scheduled workflows that keep the repo healthy without anyone needing to remember to check on it. No code changes, no version bump.

### `nightly.yml` — weekly toolchain check

Weekly cron on Tuesday 04:23 UTC (deliberately off-cycle from Renovate's Monday slot so they don't fight for runner time). Runs the same things as PR CI — wrapper validation, unit tests, release APK, lint — but on a schedule.

The point is to catch regressions that sneak in without any human-driven activity on the repo. Examples of what this would have caught (or will):

- A Renovate auto-merge that compiles fine but breaks lint
- An Android Gradle Plugin update that surfaces a new lint warning at the strict level
- A transitive dependency change that breaks a test
- An upstream JDK / Gradle update that the runner picks up

On failure it opens a single rolling "Nightly build failed" issue with a link to the run. If the next week also fails, it comments on the existing issue rather than opening a new one — no spam if a regression takes a couple of weeks to track down.

### `stale.yml` — issue + PR housekeeping

Runs daily. Costs seconds.

| | Idle before stale | Idle before close | Notes |
| --- | --- | --- | --- |
| Issues | 30 days | 30 more days | Friendly "still relevant?" nudge before close |
| PRs | 60 days | 30 more days | More lenient since contributors may need time |

Exempt labels (won't auto-stale or close):

- Issues: `pinned`, `bug`, `security`, `help wanted`, `good first issue`, `confirmed`, `nightly-failure`
- PRs: `pinned`, `wip`, `blocked`

Anything with an assignee or a milestone is also exempt — someone's actively on it.

The wording is intentionally polite — it's about keeping the inbox honest, not brushing reporters off. The close message specifically says "reopen any time".

### Why these two together

Both are about the same thing: the repo should self-maintain to the extent possible. Nightly catches code regressions; stale catches inbox decay. Combined with PR #19 (CodeQL, weekly) and PR #20 (Renovate, weekly), the project now has automated coverage on:

- Dependencies (Renovate, Mondays)
- Toolchain regressions (nightly, Tuesdays)
- Security findings (CodeQL, Mondays + on every PR)
- Inbox decay (stale, daily)

Nothing here requires anyone to remember to do anything. Failures show up as issues; everything else stays quiet.

## Test plan

- [ ] Merge this PR
- [ ] Manual trigger of nightly via Actions → Nightly build → Run workflow → confirm it passes on a clean master
- [ ] Manual trigger of stale via Actions → Stale → Run workflow → confirm it runs without touching anything (no idle issues today)
- [ ] First Tuesday after merge: scheduled nightly run completes; if it fails, the rolling issue opens
- [ ] Confirm the daily stale run shows up in Actions history starting tomorrow