### PR TITLE
fix(perf): Compose lint bugs + manifest scoping (v1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.4.1 — Small Compose performance + manifest fixes
+
+A handful of real fixes pulled out of the Android lint report. None
+of these are visible as new features, but a couple were affecting
+playback and the lyrics screen in subtle ways.
+
+- The synced-lyrics view was creating a new Kotlin Flow on every
+  recomposition (one for each visible line, every time a state
+  change triggered a redraw). The `collectAsState` reading from that
+  flow was effectively being reset on each pass, so position updates
+  could be missed and the line-highlight could feel a beat behind on
+  busy songs. The flow is now built once and reused — same data,
+  much less churn.
+
+- Three places used `Modifier.offset(x = state)` with state-backed
+  values: the lyrics-mode capsule indicator, the segment-options
+  capsule in Settings, and the seek-bar handle position. Each one
+  was triggering a recomposition every animation frame instead of
+  just relayout. Switched to the lambda overload
+  (`Modifier.offset { IntOffset(...) }`) which defers the offset
+  read to the layout phase. Smoother animation, lower CPU during
+  playback.
+
+- The manifest declared `READ_EXTERNAL_STORAGE` and
+  `WRITE_EXTERNAL_STORAGE` without a max-SDK cap. On Android 13+
+  these are deprecated and not granted at runtime — `READ_MEDIA_AUDIO`
+  takes their place. They're now scoped with `android:maxSdkVersion="32"`
+  so they only register on devices that actually use them. No
+  behaviour change on any version, just cleaner manifest output.
+
 ## 1.4.0 — NetEase as a lyrics backup, plus a cache fix
 
 If LRCLIB doesn't have the lyrics you're looking for, the app now

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_004_000
-        versionName = "1.4.0-community"
+        versionCode = 1_004_001
+        versionName = "1.4.1-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,8 +10,16 @@
          notifications when the foreground service starts. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- Legacy storage permissions are only granted up to API 32; on Android
+         13+ READ_MEDIA_AUDIO replaces them. The maxSdkVersion attribute keeps
+         older devices working without leaving a deprecated permission in the
+         install dialog on newer ones. -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/LyricsSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/LyricsSheet.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -109,6 +110,13 @@ fun LyricsSheet(
         derivedStateOf {
             playbackState.lyrics
         }
+    }
+    // Hoist the position-only flow once. Building it inside the itemsIndexed
+    // body recreates a new Flow on every recomposition, which resets the
+    // collectAsState() inside SyncedLyricsLine / BubblesLine (Compose lint
+    // warning FlowOperatorInvokedInComposition).
+    val positionFlow = remember(playbackStateFlow) {
+        playbackStateFlow.map { it.position }
     }
     var collapseFraction by remember {
         mutableFloatStateOf(0f)
@@ -252,7 +260,7 @@ fun LyricsSheet(
 
                                 if (line.isNotBlank()) {
                                     SyncedLyricsLine(
-                                        positionFlow = playbackStateFlow.map { it.position },
+                                        positionFlow = positionFlow,
                                         time = time,
                                         nextTime = nextTime,
                                         line = line,
@@ -282,7 +290,7 @@ fun LyricsSheet(
                                     )
                                 } else {
                                     BubblesLine(
-                                        positionFlow = playbackStateFlow.map { it.position },
+                                        positionFlow = positionFlow,
                                         time = time,
                                         nextTime = nextTime,
                                         modifier = Modifier.align(
@@ -375,7 +383,10 @@ fun LyricsTypeSwitch(
             modifier = Modifier
                 .fillMaxHeight()
                 .fillMaxWidth(.5f)
-                .offset(x = capsuleOffset)
+                // Lambda overload defers offset evaluation to the layout
+                // phase, so changes to capsuleOffset don't trigger
+                // recomposition of this Box.
+                .offset { IntOffset(x = capsuleOffset.roundToPx(), y = 0) }
                 .clip(ShapeDefaults.ExtraLarge)
                 .background(color = contentColor.copy(alpha = .1f))
         )

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/WavingSeekBar.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/WavingSeekBar.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
@@ -208,18 +209,23 @@ fun WavingSeekBar(
                 }
             }
 
+            // animateDpAsState is composable so the call has to live up here
+            // rather than inside the offset {} lambda (which runs in
+            // Density, not Composable, scope).
+            val animatedHandleOffset by animateDpAsState(
+                targetValue = with(density) {
+                    handleOffset.toDp() - (handleSize + handlePadding * 2) / 2
+                },
+                label = "seek-bar-handle-position-animation"
+            )
+
             SeekBarHandle(
                 modifier = Modifier
                     .size(handleSize + handlePadding * 2)
                     .padding(handlePadding)
-                    .offset(
-                        x = animateDpAsState(
-                            targetValue = with(density) {
-                                handleOffset.toDp() - (handleSize + handlePadding * 2) / 2
-                            },
-                            label = "seek-bar-handle-position-animation"
-                        ).value
-                    )
+                    .offset {
+                        IntOffset(x = animatedHandleOffset.roundToPx(), y = 0)
+                    }
                     .pointerInput(Unit) {
                         detectDragGestures(
                             onDragStart = {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingSegmentOptions.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingSegmentOptions.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEachIndexed
 
@@ -90,7 +91,7 @@ fun SettingSegmentOptions(
                 modifier = Modifier
                     .fillMaxHeight()
                     .fillMaxWidth(.5f)
-                    .offset(x = capsuleOffset)
+                    .offset { IntOffset(x = capsuleOffset.roundToPx(), y = 0) }
                     .clip(ShapeDefaults.ExtraLarge)
                     .background(color = MaterialTheme.colorScheme.primary)
             )


### PR DESCRIPTION
## What's in v1.4.1

Three categories of real fixes pulled out of the Android lint report. Style noise (FunctionNaming, MagicNumber, formatting, etc.) deliberately left alone — those are baseline candidates for a future strict-lint pass, not bugs.

### `FlowOperatorInvokedInComposition` — LyricsSheet position flow

`LyricsSheet.kt:255` and `:285` both called `playbackStateFlow.map { it.position }` directly inside the `itemsIndexed` body. Every visible synced-lyrics line got a fresh `Flow` on every recomposition; the downstream `collectAsState` inside `SyncedLyricsLine` / `BubblesLine` was effectively being reset each pass.

Symptom: position updates could be dropped on busy renders, and the line-highlight could feel a beat behind on songs with rapid lyric changes.

Fix: hoist the mapped flow once at the `LyricsSheet` level, pass the same `Flow<Long>` instance into both call sites:

```kotlin
val positionFlow = remember(playbackStateFlow) {
    playbackStateFlow.map { it.position }
}
```

### `UseOfNonLambdaOffsetOverload` — three animation hot paths

`Modifier.offset(x = ...)` reads the offset value during composition. When that value is state-backed (e.g. `animateDpAsState`), every animation frame triggers a recomposition just to relayout. The lambda overload `Modifier.offset { IntOffset(...) }` defers the read to the layout phase — same visual result, no recomposition churn.

Three sites fixed:

- `LyricsSheet.kt:378` — lyrics-mode toggle capsule
- `SettingSegmentOptions.kt:93` — segmented-options capsule (used in Settings)
- `WavingSeekBar.kt:215` — seek-bar handle position

`WavingSeekBar` needed a small restructure: `animateDpAsState` is composable, so the call had to move to a `by` declaration above the `Modifier` chain. The lambda inside `offset {}` runs in `Density` scope, not `Composable`.

### `ScopedStorage` — manifest cleanup

`READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` were declared without a max-SDK cap. On API 33+ these have been replaced by `READ_MEDIA_AUDIO` and aren't granted at runtime anyway — declaring them unconditionally just bloats the install dialog on modern devices.

Both now scoped with `android:maxSdkVersion=\"32\"` so they only register on devices that actually use them. No behaviour change on any version.

### What was deliberately skipped

- `OldTargetApi` — targetSdk 35 is current stable, the lint warning is preview-version noise.
- `ModifierParameter` — Compose convention nit (modifier should be the first optional parameter); affects API ergonomics, not runtime behaviour.
- `UnusedResources` — dead code, but not bugs. Cleanup PR for another day.
- `Typos` / `TypographyEllipsis` / `Usability:Icons` — string and asset cosmetics.
- `IconXmlAndPng` / `VectorPath` — minor APK-size and parse-time things.
- `AndroidGradlePluginVersion` / `GradleDependency` — Renovate handles these.

### Version

- `versionCode 1_004_000 → 1_004_001`
- `versionName 1.4.0-community → 1.4.1-community`

Patch bump because these are bug fixes, not features.

## Test plan

- [ ] Play a song with synced lyrics → line-highlight tracks position smoothly, no perceptible lag, scrolls in time
- [ ] Toggle the synced/plain switch in the lyrics screen → capsule slides smoothly
- [ ] Open Settings → any screen with a segment-options control (e.g. Theme) → the selected-option capsule slides smoothly
- [ ] Drag the seek bar handle → drag is smooth, snaps to position on release
- [ ] Profile (optional, with the layout-inspector or `adb shell dumpsys gfxinfo`): recompositions per second during a playing track should drop
- [ ] On Android 13+ device: install dialog shows only the permissions actually used (no `READ_EXTERNAL_STORAGE`)
- [ ] On Android 12 device: install dialog still shows the legacy storage permissions, app still scans the music library
- [ ] After merge + tag `v1.4.1`: CHANGELOG-driven release notes, all five APKs ship