### PR TITLE
feat(security): network hardening + privacy controls (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.5.0 — Privacy and network hardening
+
+A few changes to how the app handles network calls and what data
+can leave your device. Nothing visible during normal use, but worth
+walking through if you care about that side of things.
+
+A new **Privacy** section in Settings, with one switch at the top —
+**Allow network lookups**. Turning it off puts the app into a strict
+offline mode: no LRCLIB, no NetEase, no MusicBrainz. The rest of the
+app keeps working from your local library. The per-provider toggles
+(like the NetEase fallback) still apply when the master switch is
+on, so you can layer the controls if you'd rather only disable some
+sources.
+
+The HTTP client is now stricter about a few things:
+
+- **HTTPS only**, enforced at the OS level via a network security
+  config. Even a hypothetical bug that tried to hit a plain HTTP URL
+  would be refused.
+- **System CAs only**. User-installed certificate authorities are
+  not trusted. This blocks corporate MITM proxies and any custom CA
+  on the device from intercepting Lotus's traffic. Debug builds
+  still allow user CAs so developers can run local proxies; release
+  builds don't.
+- **No automatic redirect-following.** A poisoned DNS response or a
+  misbehaving upstream that tries to 30x-redirect somewhere
+  unexpected now fails loudly instead of silently following the
+  redirect to wherever. The one place that legitimately needs to
+  follow a redirect (CoverArtArchive, which serves album art via a
+  CDN) does so explicitly, with the destination URL validated
+  against an allow-list.
+- **Response size cap of 5 MB.** A malicious or buggy upstream
+  can't send a multi-gigabyte body that fills memory. Generous
+  enough that no real lookup hits it.
+
+Backup and device-transfer rules are now explicit. Your settings
+(theme, tab order, sort prefs, etc.) still survive a reinstall.
+The lyrics cache and crash logs do not — listening history is the
+kind of thing that shouldn't be quietly riding to Google's servers
+along with the rest of your Auto Backup.
+
+None of this changes how the app behaves day-to-day. The provider
+endpoints are the same, the data sent to them is the same, and the
+default state for upgrading users is unchanged. The tightening is
+underneath.
+
 ## 1.4.1 — Small Compose performance + manifest fixes
 
 A handful of real fixes pulled out of the Android lint report. None

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_004_001
-        versionName = "1.4.1-community"
+        versionCode = 1_005_000
+        versionName = "1.5.0-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MusicPlayer.Splash"

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/metadata/GatedMetadataProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/metadata/GatedMetadataProvider.kt
@@ -1,0 +1,32 @@
+package com.dn0ne.player.app.data.remote.metadata
+
+import com.dn0ne.player.app.domain.metadata.MetadataSearchResult
+import com.dn0ne.player.app.domain.result.DataError
+import com.dn0ne.player.app.domain.result.Result
+
+// Wraps a real MetadataProvider with a runtime enable check. When disabled
+// every call returns a "no internet" style result without touching the
+// network. The same shape exists for lyrics in GatedLyricsProvider.
+class GatedMetadataProvider(
+    private val delegate: MetadataProvider,
+    private val isEnabled: () -> Boolean,
+) : MetadataProvider {
+    override suspend fun searchMetadata(
+        query: String,
+        trackDuration: Long,
+    ): Result<List<MetadataSearchResult>, DataError> =
+        if (isEnabled()) {
+            delegate.searchMetadata(query, trackDuration)
+        } else {
+            Result.Error(DataError.Network.NoInternet)
+        }
+
+    override suspend fun getCoverArtBytes(
+        searchResult: MetadataSearchResult,
+    ): Result<ByteArray, DataError> =
+        if (isEnabled()) {
+            delegate.getCoverArtBytes(searchResult)
+        } else {
+            Result.Error(DataError.Network.NoInternet)
+        }
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/remote/metadata/MusicBrainzMetadataProvider.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/remote/metadata/MusicBrainzMetadataProvider.kt
@@ -159,12 +159,13 @@ class MusicBrainzMetadataProvider(
                 }
             }
 
-            HttpStatusCode.TemporaryRedirect -> {
-                // Ktor's default config follows redirects automatically, so
-                // we shouldn't see this in practice. Log + treat as unknown
-                // so future regressions in redirect handling surface clearly.
-                Log.d(logTag, "Unexpected 307 from CoverArtArchive: ${response.bodyAsText()}")
-                return Result.Error(DataError.Network.Unknown)
+            HttpStatusCode.TemporaryRedirect, HttpStatusCode.PermanentRedirect -> {
+                // CoverArtArchive 30x-redirects to its CDN (archive.org / S3)
+                // for the actual image bytes. The shared HttpClient has
+                // followRedirects = false as a defence-in-depth measure, so
+                // we follow this one redirect ourselves with explicit checks
+                // on the destination URL.
+                return followCoverArtRedirect(response)
             }
 
             HttpStatusCode.BadRequest -> {
@@ -180,6 +181,59 @@ class MusicBrainzMetadataProvider(
             }
 
             else -> return Result.Error(DataError.Network.Unknown)
+        }
+    }
+
+    // Follows a single 30x from CoverArtArchive after validating the
+    // destination. Anything sketchy (missing Location, non-HTTPS scheme,
+    // unknown host) errors out instead of being followed. This is the only
+    // place in the app that follows a redirect — everywhere else uses the
+    // strict client default.
+    private suspend fun followCoverArtRedirect(
+        response: io.ktor.client.statement.HttpResponse,
+    ): Result<ByteArray, DataError> {
+        val location = response.headers[HttpHeaders.Location]
+        if (location.isNullOrBlank()) {
+            Log.w(logTag, "CoverArtArchive redirect missing Location header")
+            return Result.Error(DataError.Network.Unknown)
+        }
+        if (!location.startsWith("https://")) {
+            Log.w(logTag, "Refusing non-HTTPS CoverArtArchive redirect: $location")
+            return Result.Error(DataError.Network.Unknown)
+        }
+        // Allow-list of redirect targets that CoverArtArchive uses in
+        // practice. If they ever add a new CDN host we'll see this fail
+        // loudly rather than silently following somewhere unexpected.
+        val allowed = listOf("archive.org", "ia800", "ia801", "ia802", "ia803", "ia804", "ia902", "ia903", "ia904", "ia905")
+        val host = io.ktor.http.Url(location).host
+        if (allowed.none { host.contains(it) }) {
+            Log.w(logTag, "Refusing CoverArtArchive redirect to unexpected host: $host")
+            return Result.Error(DataError.Network.Unknown)
+        }
+
+        val final = try {
+            client.get(location) {
+                headers { append(HttpHeaders.UserAgent, userAgent) }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            return Result.Error(e.toNetworkError())
+        }
+
+        return when (final.status) {
+            HttpStatusCode.OK -> {
+                try {
+                    Result.Success(final.body<ByteArray>())
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    Log.w(logTag, "Failed to read cover-art body after redirect", e)
+                    Result.Error(DataError.Network.ParseError)
+                }
+            }
+            HttpStatusCode.NotFound -> Result.Error(DataError.Network.NotFound)
+            else -> Result.Error(DataError.Network.Unknown)
         }
     }
 

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -16,6 +16,7 @@ import com.dn0ne.player.app.data.remote.lyrics.LrclibLyricsProvider
 import com.dn0ne.player.app.data.remote.lyrics.LyricsProvider
 import com.dn0ne.player.app.data.remote.lyrics.NetEaseLyricsProvider
 import com.dn0ne.player.core.data.Settings
+import com.dn0ne.player.app.data.remote.metadata.GatedMetadataProvider
 import com.dn0ne.player.app.data.remote.metadata.MetadataProvider
 import com.dn0ne.player.app.data.remote.metadata.MusicBrainzMetadataProvider
 import com.dn0ne.player.app.data.repository.LyricsRepository
@@ -27,13 +28,22 @@ import com.dn0ne.player.app.data.repository.TrackRepositoryImpl
 import com.dn0ne.player.app.presentation.PlayerViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpResponseValidator
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.contentLength
 import io.ktor.serialization.kotlinx.json.json
+import java.io.IOException
 import kotlinx.serialization.json.Json
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
+
+// 5 MB is well above the largest legitimate response we make (album cover
+// art tops out around a couple hundred KB; lyrics and JSON metadata are
+// tiny). Picked to leave generous headroom while still catching the
+// "firehose" attack shape.
+private const val MAX_RESPONSE_BYTES = 5L * 1024 * 1024
 
 val playerModule = module {
 
@@ -52,6 +62,14 @@ val playerModule = module {
 
     single<HttpClient> {
         HttpClient(CIO) {
+            // Strict redirect policy: don't auto-follow. A poisoned DNS
+            // response or a misbehaving upstream that returns a 30x can
+            // divert the request anywhere; we'd rather see that as an error
+            // and decide what to do. The one place that legitimately needs
+            // a redirect (CoverArtArchive → S3) handles its own 307 with
+            // explicit URL validation.
+            followRedirects = false
+
             install(ContentNegotiation) {
                 json(
                     Json {
@@ -68,13 +86,34 @@ val playerModule = module {
                 connectTimeoutMillis = 10_000
                 socketTimeoutMillis = 15_000
             }
+
+            // Cap response size so a malicious or buggy upstream can't fill
+            // memory with a multi-GB body. Headers-phase only — checks the
+            // declared Content-Length before we consume the body. Responses
+            // that omit Content-Length still get killed by socketTimeout
+            // long before they fill anything significant.
+            HttpResponseValidator {
+                validateResponse { response ->
+                    val length = response.contentLength()
+                    if (length != null && length > MAX_RESPONSE_BYTES) {
+                        throw IOException(
+                            "Refusing response: declared Content-Length " +
+                                "$length exceeds cap of $MAX_RESPONSE_BYTES",
+                        )
+                    }
+                }
+            }
         }
     }
 
     single<MetadataProvider> {
-        MusicBrainzMetadataProvider(
-            context = androidContext(),
-            client = get()
+        val settings = get<Settings>()
+        GatedMetadataProvider(
+            delegate = MusicBrainzMetadataProvider(
+                context = androidContext(),
+                client = get(),
+            ),
+            isEnabled = { settings.networkLookupsEnabled },
         )
     }
 
@@ -92,7 +131,13 @@ val playerModule = module {
             delegate = NetEaseLyricsProvider(client = get()),
             isEnabled = { settings.useNetEaseLyricsFallback },
         )
-        ChainLyricsProvider(listOf(lrclib, netEase))
+        // Outer gate: master switch for all lyrics network calls. When the
+        // user has disabled network lookups in Settings → Privacy, the
+        // chain short-circuits before consulting either provider.
+        GatedLyricsProvider(
+            delegate = ChainLyricsProvider(listOf(lrclib, netEase)),
+            isEnabled = { settings.networkLookupsEnabled },
+        )
     }
 
     single<LotusDatabase> {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/PrivacySettings.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/PrivacySettings.kt
@@ -1,0 +1,91 @@
+package com.dn0ne.player.app.presentation.components.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBackIosNew
+import androidx.compose.material.icons.rounded.CloudOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import com.dn0ne.player.R
+import com.dn0ne.player.app.presentation.components.topbar.ColumnWithCollapsibleTopBar
+import com.dn0ne.player.core.data.Settings
+
+@Composable
+fun PrivacySettings(
+    settings: Settings,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var collapseFraction by remember { mutableFloatStateOf(0f) }
+
+    ColumnWithCollapsibleTopBar(
+        topBarContent = {
+            IconButton(
+                onClick = onBackClick,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.ArrowBackIosNew,
+                    contentDescription = context.resources.getString(R.string.back),
+                )
+            }
+
+            Text(
+                text = context.resources.getString(R.string.privacy),
+                fontSize = lerp(
+                    MaterialTheme.typography.titleLarge.fontSize,
+                    MaterialTheme.typography.displaySmall.fontSize,
+                    collapseFraction,
+                ),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(horizontal = 16.dp),
+            )
+        },
+        collapseFraction = { collapseFraction = it },
+        contentPadding = PaddingValues(horizontal = 28.dp),
+        contentHorizontalAlignment = Alignment.CenterHorizontally,
+        contentVerticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .safeDrawingPadding(),
+    ) {
+        var networkLookupsEnabled by remember {
+            mutableStateOf(settings.networkLookupsEnabled)
+        }
+        SettingSwitch(
+            title = context.resources.getString(R.string.network_lookups),
+            supportingText = context.resources.getString(R.string.network_lookups_explain),
+            icon = Icons.Rounded.CloudOff,
+            isChecked = networkLookupsEnabled,
+            onCheckedChange = {
+                settings.networkLookupsEnabled = it
+                networkLookupsEnabled = it
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingsSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingsSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
 import androidx.compose.material.icons.rounded.ArrowBackIosNew
 import androidx.compose.material.icons.rounded.ColorLens
 import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Radar
@@ -195,6 +196,14 @@ fun SettingsSheet(
                                     onClick = {
                                         navController.navigate(SettingsRoutes.Lyrics)
                                     }
+                                ),
+                                SettingsItem(
+                                    title = context.resources.getString(R.string.privacy),
+                                    supportingText = context.resources.getString(R.string.privacy_supporting_text),
+                                    icon = Icons.Rounded.Lock,
+                                    onClick = {
+                                        navController.navigate(SettingsRoutes.Privacy)
+                                    }
                                 )
                             )
                         }
@@ -285,6 +294,16 @@ fun SettingsSheet(
                     )
                 }
 
+                composable<SettingsRoutes.Privacy> {
+                    PrivacySettings(
+                        settings = state.settings,
+                        onBackClick = {
+                            navController.navigateUp()
+                        },
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+
                 composable<SettingsRoutes.About> {
                     AboutPage(
                         onBackClick = {
@@ -320,6 +339,9 @@ sealed interface SettingsRoutes {
 
     @Serializable
     data object Lyrics : SettingsRoutes
+
+    @Serializable
+    data object Privacy : SettingsRoutes
 
     @Serializable
     data object About : SettingsRoutes

--- a/app/src/main/java/com/dn0ne/player/core/data/Settings.kt
+++ b/app/src/main/java/com/dn0ne/player/core/data/Settings.kt
@@ -33,6 +33,7 @@ class Settings(context: Context) {
     private val lyricsAlignmentKey = "lyrics-alignment"
     private val useDarkPaletteOnLyricsSheetKey = "dark-palette-on-lyrics-sheet"
     private val useNetEaseLyricsFallbackKey = "use-netease-lyrics-fallback"
+    private val networkLookupsEnabledKey = "network-lookups-enabled"
 
     private val areRisksOfMetadataEditingAcceptedKey = "metadata-editing-dialog"
 
@@ -225,6 +226,18 @@ class Settings(context: Context) {
         set(value) {
             with(sharedPreferences.edit()) {
                 putBoolean(useNetEaseLyricsFallbackKey, value)
+                apply()
+            }
+        }
+
+    // Master gate over every outbound HTTP call the app makes. When false,
+    // lyrics + metadata providers short-circuit before touching the network.
+    // Default true to preserve the existing behaviour for upgrading users.
+    var networkLookupsEnabled: Boolean
+        get() = sharedPreferences.getBoolean(networkLookupsEnabledKey, true)
+        set(value) {
+            with(sharedPreferences.edit()) {
+                putBoolean(networkLookupsEnabledKey, value)
                 apply()
             }
         }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -241,6 +241,10 @@
     <string name="about_explain">Версия, репозиторий, обратная связь</string>
     <string name="music_scan">Сканирование музыки</string>
     <string name="music_scan_supporting_text">Режим фильтра, управление папками, сканирование</string>
+    <string name="privacy">Конфиденциальность</string>
+    <string name="privacy_supporting_text">Что покидает устройство, управление сетью</string>
+    <string name="network_lookups">Разрешить сетевые запросы</string>
+    <string name="network_lookups_explain">Главный переключатель для LRCLIB, NetEase и MusicBrainz. Отключите для строго офлайн-режима — остальная часть приложения продолжит работать с локальной библиотекой.</string>
 
     <!-- Theme settings -->
     <string name="appearance">Оформление</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -241,6 +241,10 @@
     <string name="about_explain">Версія, репозиторій, зворотній зв\'язок</string>
     <string name="music_scan">Сканування музики</string>
     <string name="music_scan_supporting_text">Режим фільтру, керування папками, сканування</string>
+    <string name="privacy">Конфіденційність</string>
+    <string name="privacy_supporting_text">Що залишає пристрій, керування мережею</string>
+    <string name="network_lookups">Дозволити мережеві запити</string>
+    <string name="network_lookups_explain">Головний перемикач для LRCLIB, NetEase та MusicBrainz. Вимкніть для суворо офлайн-режиму — решта додатка продовжить працювати з локальною бібліотекою.</string>
 
     <!-- Theme settings -->
     <string name="appearance">Оформлення</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,10 @@
     <string name="about_explain">Version, repository, feedback</string>
     <string name="music_scan">Music scan</string>
     <string name="music_scan_supporting_text">Filter mode, folder management, scanning</string>
+    <string name="privacy">Privacy</string>
+    <string name="privacy_supporting_text">What leaves your device, network controls</string>
+    <string name="network_lookups">Allow network lookups</string>
+    <string name="network_lookups_explain">Master switch for LRCLIB lyrics, NetEase lyrics, and MusicBrainz metadata. Turn off for a strict-offline mode — the rest of the app keeps working from your local library.</string>
 
     <!-- Theme settings -->
     <string name="appearance">Appearance</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Auto-backup rules for API < 31. Mirror what data_extraction_rules.xml
+  does for API 31+ so the policy is the same on every supported version.
+
+  Allowed in backups: SharedPreferences (theme, tab order, sort prefs,
+  network toggles, etc.). These are user choices we'd like to survive a
+  reinstall and contain nothing private.
+
+  Excluded: the Room database (lotus.db — caches lyrics that the user
+  has fetched, which is effectively a record of what they've looked
+  up) and the crash-logs directory (FileProvider-exposed for in-app
+  share, but we don't need them riding to Google's servers).
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <include domain="sharedpref" path="." />
+
+    <exclude domain="database" path="lotus.db" />
+    <exclude domain="database" path="lotus.db-journal" />
+    <exclude domain="database" path="lotus.db-shm" />
+    <exclude domain="database" path="lotus.db-wal" />
+
+    <exclude domain="file" path="crash-logs/" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,36 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Backup / device-transfer rules for API 31+. Same policy as
+  backup_rules.xml (which covers older versions): include only the
+  SharedPreferences, exclude the Room DB and crash logs.
+
+  cloud-backup is what gets uploaded to Google's servers when the
+  user has Auto Backup enabled. device-transfer is the local
+  device-to-device migration path.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <include domain="sharedpref" path="." />
+
+        <exclude domain="database" path="lotus.db" />
+        <exclude domain="database" path="lotus.db-journal" />
+        <exclude domain="database" path="lotus.db-shm" />
+        <exclude domain="database" path="lotus.db-wal" />
+
+        <exclude domain="file" path="crash-logs/" />
     </cloud-backup>
-    <!--
+
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <include domain="sharedpref" path="." />
+
+        <!-- Lyrics cache + crash logs stay local on device transfer too;
+             user can re-fetch lyrics on demand, and crash logs from a
+             previous device aren't useful on the new one. -->
+        <exclude domain="database" path="lotus.db" />
+        <exclude domain="database" path="lotus.db-journal" />
+        <exclude domain="database" path="lotus.db-shm" />
+        <exclude domain="database" path="lotus.db-wal" />
+
+        <exclude domain="file" path="crash-logs/" />
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Locks down all of the app's network behaviour. Three things going on:
+
+  1. base-config: HTTPS only everywhere; trust anchors limited to the
+     system CA store. User-installed CAs are NOT trusted, which blocks
+     corporate MITM proxies and any hand-rolled CA on the device from
+     intercepting our traffic. Debug builds keep user CAs trusted via
+     base-config in debug-overrides (further down) so devs can run a
+     local proxy when they need to.
+
+  2. domain-config: pins each known endpoint to the same strict policy.
+     Belt-and-braces — nothing in the codebase should be hitting any
+     other host, but if a future bug or compromised dep tries to, the
+     system CA + cleartext-off rules from base-config still apply.
+
+  3. debug-overrides: only the debug build allows user CAs (so devs can
+     proxy through Charles / mitmproxy). Release builds get no override.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">lrclib.net</domain>
+        <domain includeSubdomains="true">music.163.com</domain>
+        <domain includeSubdomains="true">musicbrainz.org</domain>
+        <domain includeSubdomains="true">coverartarchive.org</domain>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </domain-config>
+
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
## What's in v1.5.0

Five changes that tighten how the app handles network calls and what data can leave your device. None of them change behaviour for upgrading users at default settings — the tightening is underneath.

### 1. Network security config

New `res/xml/network_security_config.xml`, referenced from the manifest. Enforces:

- `cleartextTrafficPermitted=\"false\"` everywhere — even a hypothetical bug that tried to hit a plain HTTP URL gets refused at the OS level
- **System CAs only.** User-installed CAs are not trusted, which blocks corporate MITM proxies and any device-level cert injection from intercepting Lotus traffic
- Per-domain config for the four hosts the app actually talks to: `lrclib.net`, `music.163.com`, `musicbrainz.org`, `coverartarchive.org`
- `debug-overrides` allow user CAs in debug builds so devs can run mitmproxy / Charles locally; release builds get no override

### 2. No automatic redirect-following

`HttpClient` in `PlayerModule` now has `followRedirects = false`. A poisoned DNS response or a misbehaving upstream that 30x-redirects somewhere unexpected fails loudly instead of silently following the redirect to wherever.

The one place that legitimately needs to follow a redirect (CoverArtArchive serves album art via a CDN) does so manually with explicit checks. New `followCoverArtRedirect()` in `MusicBrainzMetadataProvider`:

1. Reads the `Location` header; refuses if missing
2. Refuses if the destination isn't HTTPS
3. Refuses if the host isn't in the allow-list (`archive.org`, `ia80x`, `ia90x` CDN hosts)
4. Follows the redirect once and processes the response

### 3. Response size cap

`HttpResponseValidator` enforces a 5 MB max on `Content-Length`. Well above any legitimate response we make (album art tops out at ~hundreds of KB, lyrics and JSON are tiny); blocks the \"firehose\" attack shape where a malicious upstream sends a multi-GB body to OOM the device.

Responses without `Content-Length` still get killed by the existing `socketTimeoutMillis = 15_000`.

### 4. Backup rules made explicit

Both `backup_rules.xml` (API <31) and `data_extraction_rules.xml` (API 31+) now have explicit policy:

- **Include**: `sharedpref` (theme, tab order, sort prefs, network toggles) — these survive reinstall, contain nothing private
- **Exclude**: `lotus.db` + WAL/journal/shm files — the lyrics cache is effectively a record of what tracks the user has looked up
- **Exclude**: `crash-logs/` — FileProvider-exposed for in-app share, no reason to upload to backup servers

Same policy for both `cloud-backup` (Google Auto Backup) and `device-transfer` (local migration).

### 5. Master kill switch

New `Settings.networkLookupsEnabled` flag (default `true`). Two `GatedXProvider` wrappers in DI:

- `ChainLyricsProvider` wrapped in an outer `GatedLyricsProvider` gated on the master flag. The existing NetEase per-provider gate is the inner gate.
- `MusicBrainzMetadataProvider` wrapped in new `GatedMetadataProvider` with the same gate.

When the master is off, every provider returns a `DataError.Network` immediately without touching the network. Per-provider switches still apply when the master is on, so users can layer the controls.

New `PrivacySettings` screen reachable from main Settings → Privacy. Currently has just the master switch. **v1.5.1 will flesh this out with the disclosure copy** (what each network feature sends, to where, under what conditions).

### Version

- `versionCode 1_004_001 → 1_005_000`
- `versionName 1.4.1-community → 1.5.0-community`

Minor bump because of the new Privacy screen + flag.

## Test plan

- [ ] Default install: lyrics + metadata search still work as before (LRCLIB, NetEase fallback if enabled, MusicBrainz)
- [ ] Settings → Privacy → toggle master off → all three providers stop hitting the network; the lyrics screen shows the appropriate \"not available\" message; metadata search returns empty
- [ ] Toggle master back on → providers resume working
- [ ] With master on, NetEase per-provider toggle off → LRCLIB works, NetEase doesn't (existing behaviour)
- [ ] Cover art still loads in metadata-search results (validates the manual 307 follow path)
- [ ] On Android 7+ (API 24+): manifest declares `networkSecurityConfig` and the app starts cleanly
- [ ] Reinstall path: settings (theme, sort prefs) survive; lyrics cache is empty after reinstall; lyrics re-fetched on demand
- [ ] After merge + tag `v1.5.0`: CHANGELOG-driven release notes, all five APKs ship