### PR TITLE
feat(privacy): disclosure panel on Privacy screen (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.5.1 — Privacy disclosure on the Privacy screen
+
+The Privacy screen added in 1.5.0 had only the master kill switch
+on it. This release fills out the rest: a plain-English breakdown
+of what the app sends, where it goes, and what stays local.
+
+Five small cards, in two sections.
+
+**What leaves your device** lists the three outbound features:
+
+- LRCLIB sends track title, artist, album if known, and duration
+  when you open the lyrics view for a track that doesn't have
+  lyrics cached.
+- NetEase sends track title and artist as a fallback when LRCLIB
+  has nothing, only if you have the NetEase fallback enabled.
+- MusicBrainz sends the search query you type plus the track's
+  duration, only when you tap Search on the metadata screen.
+
+**What stays on your device** lists the local data: lyrics cache,
+scan results, settings, and crash logs. Sharing a crash log is a
+manual action through the system share sheet — nothing is sent on
+its own.
+
+A final card states what isn't there: no analytics, no usage
+tracking, no diagnostic uploads.
+
+The disclosure exists so you don't have to read the source to
+answer "what does this app do with my data". The text is
+deliberately short — if you want the full picture, the source is
+on GitHub.
+
 ## 1.5.0 — Privacy and network hardening
 
 A few changes to how the app handles network calls and what data

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_005_000
-        versionName = "1.5.0-community"
+        versionCode = 1_005_001
+        versionName = "1.5.1-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/PrivacySettings.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/PrivacySettings.kt
@@ -2,13 +2,19 @@ package com.dn0ne.player.app.presentation.components.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowBackIosNew
+import androidx.compose.material.icons.rounded.Cloud
 import androidx.compose.material.icons.rounded.CloudOff
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.Public
+import androidx.compose.material.icons.rounded.Shield
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -26,6 +32,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import com.dn0ne.player.R
+import com.dn0ne.player.app.presentation.components.NoteCard
 import com.dn0ne.player.app.presentation.components.topbar.ColumnWithCollapsibleTopBar
 import com.dn0ne.player.core.data.Settings
 
@@ -87,5 +94,80 @@ fun PrivacySettings(
             },
             modifier = Modifier.fillMaxWidth(),
         )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SectionLabel(text = context.resources.getString(R.string.privacy_what_leaves))
+
+        NoteCard(
+            label = context.resources.getString(R.string.privacy_lrclib_title),
+            leadingIcon = Icons.Rounded.Cloud,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = context.resources.getString(R.string.privacy_lrclib_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        NoteCard(
+            label = context.resources.getString(R.string.privacy_netease_title),
+            leadingIcon = Icons.Rounded.Cloud,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = context.resources.getString(R.string.privacy_netease_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        NoteCard(
+            label = context.resources.getString(R.string.privacy_musicbrainz_title),
+            leadingIcon = Icons.Rounded.Public,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = context.resources.getString(R.string.privacy_musicbrainz_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SectionLabel(text = context.resources.getString(R.string.privacy_what_stays))
+
+        NoteCard(
+            label = context.resources.getString(R.string.privacy_local_title),
+            leadingIcon = Icons.Rounded.Folder,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = context.resources.getString(R.string.privacy_local_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        NoteCard(
+            label = context.resources.getString(R.string.privacy_no_telemetry_title),
+            leadingIcon = Icons.Rounded.Shield,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = context.resources.getString(R.string.privacy_no_telemetry_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
     }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 4.dp, top = 4.dp, bottom = 4.dp),
+    )
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -246,6 +246,20 @@
     <string name="network_lookups">Разрешить сетевые запросы</string>
     <string name="network_lookups_explain">Главный переключатель для LRCLIB, NetEase и MusicBrainz. Отключите для строго офлайн-режима — остальная часть приложения продолжит работать с локальной библиотекой.</string>
 
+    <!-- Privacy disclosure -->
+    <string name="privacy_what_leaves">Что покидает устройство</string>
+    <string name="privacy_what_stays">Что остаётся на устройстве</string>
+    <string name="privacy_lrclib_title">LRCLIB (lrclib.net)</string>
+    <string name="privacy_lrclib_body">Отправляется: название трека, исполнитель, альбом (если известен) и длительность. Используется для поиска синхронизированного или обычного текста. Запрос уходит только когда вы открываете экран текста для трека, текст которого ещё не закэширован.</string>
+    <string name="privacy_netease_title">NetEase (music.163.com)</string>
+    <string name="privacy_netease_body">Отправляется: название трека и исполнитель. Используется как запасной источник, если на LRCLIB ничего нет. Происходит, только если включён запасной источник NetEase (Настройки → Текст) и только после того, как LRCLIB вернул пусто.</string>
+    <string name="privacy_musicbrainz_title">MusicBrainz (musicbrainz.org, coverartarchive.org)</string>
+    <string name="privacy_musicbrainz_body">Отправляется: ваш поисковый запрос и длительность трека. Используется для поиска подходящего релиза с обложкой и метаданными. Запрос уходит только когда вы нажимаете «Поиск» на экране Информация о треке → Поиск — никогда автоматически.</string>
+    <string name="privacy_local_title">Локальные данные</string>
+    <string name="privacy_local_body">Кэш текстов, результаты сканирования музыки, настройки приложения и журналы сбоев хранятся на этом устройстве. Поделиться журналом сбоев — действие через системное меню «Поделиться»; ничего не отправляется само по себе.</string>
+    <string name="privacy_no_telemetry_title">Без телеметрии</string>
+    <string name="privacy_no_telemetry_body">Никакой аналитики, отслеживания использования или диагностических отправок. Перечисленные выше адреса — вся сетевая поверхность приложения.</string>
+
     <!-- Theme settings -->
     <string name="appearance">Оформление</string>
     <string name="appearance_system">Системное</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -246,6 +246,20 @@
     <string name="network_lookups">Дозволити мережеві запити</string>
     <string name="network_lookups_explain">Головний перемикач для LRCLIB, NetEase та MusicBrainz. Вимкніть для суворо офлайн-режиму — решта додатка продовжить працювати з локальною бібліотекою.</string>
 
+    <!-- Privacy disclosure -->
+    <string name="privacy_what_leaves">Що залишає пристрій</string>
+    <string name="privacy_what_stays">Що залишається на пристрої</string>
+    <string name="privacy_lrclib_title">LRCLIB (lrclib.net)</string>
+    <string name="privacy_lrclib_body">Надсилається: назва треку, виконавець, альбом (якщо відомий) та тривалість. Використовується для пошуку синхронізованого або звичайного тексту. Запит надсилається лише коли ви відкриваєте екран тексту для треку, текст якого ще не кешований.</string>
+    <string name="privacy_netease_title">NetEase (music.163.com)</string>
+    <string name="privacy_netease_body">Надсилається: назва треку та виконавець. Використовується як запасне джерело, коли на LRCLIB нічого немає. Відбувається, лише якщо ввімкнено запасне джерело NetEase (Налаштування → Текст) і лише після того, як LRCLIB повернув порожнє.</string>
+    <string name="privacy_musicbrainz_title">MusicBrainz (musicbrainz.org, coverartarchive.org)</string>
+    <string name="privacy_musicbrainz_body">Надсилається: ваш пошуковий запит та тривалість треку. Використовується для пошуку відповідного релізу з обкладинкою та метаданими. Запит надсилається лише коли ви натискаєте «Пошук» на екрані Інформація про трек → Пошук — ніколи автоматично.</string>
+    <string name="privacy_local_title">Локальні дані</string>
+    <string name="privacy_local_body">Кеш текстів, результати сканування музики, налаштування додатка та журнали збоїв зберігаються на цьому пристрої. Поділитися журналом збоїв — дія через системне меню «Поділитися»; нічого не надсилається саме по собі.</string>
+    <string name="privacy_no_telemetry_title">Без телеметрії</string>
+    <string name="privacy_no_telemetry_body">Жодної аналітики, відстеження використання чи діагностичних завантажень. Перелічені вище адреси — вся мережева поверхня додатка.</string>
+
     <!-- Theme settings -->
     <string name="appearance">Оформлення</string>
     <string name="appearance_system">Системне</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,20 @@
     <string name="network_lookups">Allow network lookups</string>
     <string name="network_lookups_explain">Master switch for LRCLIB lyrics, NetEase lyrics, and MusicBrainz metadata. Turn off for a strict-offline mode — the rest of the app keeps working from your local library.</string>
 
+    <!-- Privacy disclosure -->
+    <string name="privacy_what_leaves">What leaves your device</string>
+    <string name="privacy_what_stays">What stays on your device</string>
+    <string name="privacy_lrclib_title">LRCLIB (lrclib.net)</string>
+    <string name="privacy_lrclib_body">Sent: track title, artist, album if known, and duration. Used to look up matching synced or plain lyrics. Sent only when you open the lyrics view for a track that doesn\'t have lyrics cached.</string>
+    <string name="privacy_netease_title">NetEase (music.163.com)</string>
+    <string name="privacy_netease_body">Sent: track title and artist. Used as a fallback when LRCLIB has no lyrics. Only happens if you have the NetEase fallback enabled (Settings → Lyrics) and only after LRCLIB returned nothing.</string>
+    <string name="privacy_musicbrainz_title">MusicBrainz (musicbrainz.org, coverartarchive.org)</string>
+    <string name="privacy_musicbrainz_body">Sent: the search query you type, plus the track\'s duration. Used to find a matching release with cover art and metadata. Sent only when you tap Search on the Track info → Search screen — never automatically.</string>
+    <string name="privacy_local_title">Local data</string>
+    <string name="privacy_local_body">Lyrics cache, music scan results, app settings, and crash logs all live on this device. Sharing a crash log is a manual action through the system share sheet — nothing is sent on its own.</string>
+    <string name="privacy_no_telemetry_title">No telemetry</string>
+    <string name="privacy_no_telemetry_body">No analytics, no usage tracking, no diagnostic uploads. The hosts above are the entire network surface.</string>
+
     <!-- Theme settings -->
     <string name="appearance">Appearance</string>
     <string name="appearance_system">System</string>


### PR DESCRIPTION
## What's in v1.5.1

The Privacy screen from v1.5.0 shipped with only the master kill switch on it. This release adds the disclosure copy that should sit alongside it.

### Layout

Under the existing master switch, two sections of `NoteCard`s:

**What leaves your device** — three cards, one per outbound feature:

- **LRCLIB (lrclib.net)** — sends track title, artist, album if known, and duration. Triggered only when you open the lyrics view for a track without cached lyrics.
- **NetEase (music.163.com)** — sends track title and artist. Conditional fallback: only fires when the NetEase toggle is on (Settings → Lyrics) AND LRCLIB returned no match.
- **MusicBrainz (musicbrainz.org, coverartarchive.org)** — sends the search query you type plus the track's duration. Only fires when you tap Search on the Track info → Search screen — never automatic.

**What stays on your device** — two cards:

- **Local data** — lyrics cache, music scan results, app settings, crash logs. Sharing a crash log is a manual action through the system share sheet.
- **No telemetry** — no analytics, no usage tracking, no diagnostic uploads. The hosts above are the entire network surface.

### Why this and not more

The user-facing point is to answer "what does this app do with my data" without you having to read source. Five short cards covers that. Anything longer turns into a privacy policy nobody reads.

The rest of the privacy work (network security config, redirect lockdown, response cap, backup rules, kill switch wiring) shipped in v1.5.0. This is the disclosure layer on top.

### Files

- `PrivacySettings.kt` — new sections appended under the existing master switch using the existing `NoteCard` component
- `values/strings.xml` + `values-ru/` + `values-uk/` — 11 new strings, fully localised

### Version

- `versionCode 1_005_000 → 1_005_001`
- `versionName 1.5.0-community → 1.5.1-community`

Patch bump since this is purely additive UI + copy.

## Test plan

- [ ] Settings → Privacy: master switch appears at the top, then two labelled sections with cards
- [ ] Card text reads naturally on a phone (not cramped, not over-padded)
- [ ] Toggling the master switch still works exactly as before
- [ ] Switch to Russian device language: section headers and card bodies render in Russian
- [ ] Switch to Ukrainian: same
- [ ] Long-press the Privacy entry in main Settings → no crash (regression check on the route)
- [ ] After merge + tag `v1.5.1`: CHANGELOG-driven release notes, all five APKs ship