### PR TITLE
Sleep timer: presets and finish-current-track (v1.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.5.2 — Sleep timer: presets and finish-current-track
+
+Two small additions to the existing sleep timer.
+
+Preset chips above the slider — 15, 30, 45, 60, 90 minutes. The
+slider still works for anything in between; the chips are there
+for the common cases so you don't have to fiddle when the answer
+is "thirty".
+
+A **Finish current track** toggle below the slider. When it's on,
+the timer doesn't stop the player the moment it hits zero. It
+waits for the song that's already playing to end naturally and
+stops then, so you don't get cut off mid-song.
+
+The slider is also disabled while the timer is running, which
+fixes a small rough edge where dragging it mid-countdown would
+flicker the displayed minutes without changing the actual expiry
+time.
+
 ## 1.5.1 — Privacy disclosure on the Privacy screen
 
 The Privacy screen added in 1.5.0 had only the master kill switch

--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ in [CHANGELOG.md](CHANGELOG.md); summaries below are cumulative.
   30 days) and **Random mix** (up to 100 tracks shuffled). They feel
   like any other playlist — tap to open, play from, or export to M3U.
 
+### Privacy and security
+
+- **Network kill switch** — Settings → Privacy has a master toggle that
+  cuts all outbound calls (lyrics, cover art, and metadata). When it's
+  off, the app uses only what's already on disk. The optional NetEase
+  lyrics fallback has its own per-source toggle so you can pick what to
+  allow.
+- **HTTPS-only network policy** — release builds reject cleartext HTTP,
+  ignore user-installed CAs, and only talk to LRCLIB, NetEase,
+  MusicBrainz, and CoverArtArchive. Anything else fails closed.
+- **No silent redirects, response size cap** — the HTTP client follows
+  zero redirects by default; the CoverArtArchive 307 to archive.org goes
+  through an explicit handler with a host allow-list. Responses with a
+  declared length over 5 MB are refused so a misbehaving server can't
+  pin memory.
+- **Backup hygiene** — Android auto-backup and device-transfer copy
+  your settings but skip the music database and crash logs, so listening
+  history doesn't follow you to a Google account.
+- **In-app privacy disclosure** — Settings → Privacy lists exactly what
+  leaves the device (and what each upstream service sees) versus what
+  stays local. No hidden network behavior.
+
 ### Housekeeping
 
 - **Fork rebrand** — `applicationId` is `com.dn0ne.lotus.community`, so
@@ -111,9 +133,10 @@ in [CHANGELOG.md](CHANGELOG.md); summaries below are cumulative.
 - **MusicBrainz / LRCLIB contact** — the User-Agent sent with those
   API calls identifies this fork, so rate-limit or abuse reports reach
   us rather than the upstream author.
-- **Zero telemetry, zero analytics, phone-only** — no network calls
-  except LRCLIB (lyrics on demand) and MusicBrainz (optional metadata
-  search). No crash reporting SDKs, no analytics, no server.
+- **Zero telemetry, zero analytics, no server** — the only network
+  calls are the user-initiated lyrics and metadata lookups described
+  above, and all of them can be disabled. No crash reporting SDKs, no
+  analytics, no phone-home.
 
 ## Download
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_005_001
-        versionName = "1.5.1-community"
+        versionCode = 1_005_002
+        versionName = "1.5.2-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/PlaybackService.kt
+++ b/app/src/main/java/com/dn0ne/player/PlaybackService.kt
@@ -12,6 +12,7 @@ import androidx.annotation.OptIn
 import androidx.compose.ui.util.fastForEach
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -238,7 +239,26 @@ class PlaybackService : MediaSessionService() {
         })
 
         SleepTimer.addOnFinishCallback {
-            player.stop()
+            if (SleepTimer.finishLastTrack.value && player.isPlaying) {
+                val pendingStop = object : Player.Listener {
+                    override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                        if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
+                            player.stop()
+                            player.removeListener(this)
+                        }
+                    }
+
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        if (playbackState == Player.STATE_ENDED) {
+                            player.stop()
+                            player.removeListener(this)
+                        }
+                    }
+                }
+                player.addListener(pendingStop)
+            } else {
+                player.stop()
+            }
         }
 
         val intent = Intent(this, MainActivity::class.java).apply {
@@ -296,6 +316,12 @@ object SleepTimer {
 
     private val _isRunning = MutableStateFlow(false)
     val isRunning = _isRunning.asStateFlow()
+
+    private val _finishLastTrack = MutableStateFlow(false)
+    val finishLastTrack = _finishLastTrack.asStateFlow()
+    fun updateFinishLastTrack(value: Boolean) {
+        _finishLastTrack.update { value }
+    }
 
     fun start() {
         stop()

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/SleepTimerBottomSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/SleepTimerBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.dn0ne.player.app.presentation.components.playback
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,14 +9,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Timer
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -26,6 +30,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.dn0ne.player.R
 import com.dn0ne.player.SleepTimer
+
+private val sleepTimerPresets = listOf(15, 30, 45, 60, 90)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,6 +51,7 @@ fun SleepTimerBottomSheet(
         ) {
             val minutesLeft by SleepTimer.minutesLeft.collectAsState()
             val isRunning by SleepTimer.isRunning.collectAsState()
+            val finishLastTrack by SleepTimer.finishLastTrack.collectAsState()
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -84,6 +91,28 @@ fun SleepTimerBottomSheet(
                 }
             }
 
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                sleepTimerPresets.forEach { minutes ->
+                    FilterChip(
+                        selected = !isRunning && minutesLeft == minutes,
+                        onClick = { SleepTimer.updateMinutesLeft(minutes) },
+                        enabled = !isRunning,
+                        label = {
+                            Text(
+                                text = "$minutes ${context.resources.getString(R.string.short_minutes)}"
+                            )
+                        }
+                    )
+                }
+            }
+
             Spacer(modifier = Modifier.height(8.dp))
 
             Slider(
@@ -91,8 +120,27 @@ fun SleepTimerBottomSheet(
                 onValueChange = {
                     SleepTimer.updateMinutesLeft(it.toInt())
                 },
-                valueRange = 1f..120f
+                valueRange = 1f..120f,
+                enabled = !isRunning
             )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = context.resources.getString(R.string.finish_current_track),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+
+                Switch(
+                    checked = finishLastTrack,
+                    onCheckedChange = { SleepTimer.updateFinishLastTrack(it) }
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -87,6 +87,7 @@
     <string name="short_minutes">мин</string>
     <string name="stop_timer">Стоп</string>
     <string name="start_timer">Старт</string>
+    <string name="finish_current_track">Доиграть текущий трек</string>
 
     <!-- Play queue -->
     <string name="remove_from_queue">Убрать из очереди</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -87,6 +87,7 @@
     <string name="short_minutes">хв</string>
     <string name="stop_timer">Стоп</string>
     <string name="start_timer">Страт</string>
+    <string name="finish_current_track">Догравати поточний трек</string>
 
     <!-- Play queue -->
     <string name="remove_from_queue">Прибрати з черги</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <string name="short_minutes">min</string>
     <string name="stop_timer">Stop</string>
     <string name="start_timer">Start</string>
+    <string name="finish_current_track">Finish current track</string>
 
     <!-- Play queue -->
     <string name="remove_from_queue">Remove from queue</string>


### PR DESCRIPTION
## Summary

Two small refinements to the existing sleep timer, plus a README catch-up for the privacy/security work that already shipped.

**Sleep timer**

- Preset chips for 15, 30, 45, 60, 90 minutes above the slider so the common durations are one tap. Chips disable while the timer is running.
- A **Finish current track** toggle. When on, the timer reaching zero registers a one-shot `Player.Listener` that stops on the next natural track end (`STATE_ENDED` or `onMediaItemTransition` with reason `AUTO`, so user seeks and skips don't trigger early). If nothing is playing when the timer fires, the listener path is skipped and `player.stop()` is called directly.
- The slider is disabled while the timer is running. Pre-existing rough edge — dragging it mid-countdown flickered the displayed minutes without changing the actual expiry time.

**README**

- New **Privacy and security** subsection under "What this fork adds" covering the v1.5.0/v1.5.1 work: kill switch, HTTPS-only policy, no-silent-redirects + CoverArtArchive allow-list, 5 MB response cap, backup hygiene, in-app disclosure.
- Updated the Housekeeping "zero telemetry" bullet that still listed only LRCLIB and MusicBrainz as the outbound endpoints.

Strings added in EN/RU/UK. Version bumped to `1.5.2-community` (`versionCode` 1_005_002).

## Test plan

- [ ] Open the now-playing menu → Sleep timer. Verify preset chips appear and tapping one updates the slider.
- [ ] Start the timer with a low value (1 min). Verify chips and slider disable.
- [ ] Toggle **Finish current track** on with a queue of 2+ tracks. Set the timer for 1 min, start playback near the end of a track. Verify the player stops at the end of the *current* track, not at the 1-minute mark.
- [ ] Toggle **Finish current track** off. Verify the player stops at the 1-minute mark as before.
- [ ] Tap stop while running. Verify the timer cancels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)