### PR TITLE
chore(deps): bump AGP 8.9.2, Gradle 8.11.1, compileSdk 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,7 @@ val releaseSigningAvailable =
 
 android {
     namespace = "com.dn0ne.player"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.dn0ne.lotus.community"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.9.2"
 kotlin = "2.0.20"
 coreKtx = "1.15.0"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=d725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

Three open Renovate PRs are failing CI on the same root cause: the AGP / compileSdk baseline is one cycle behind the AndroidX cadence. Bumping them in one place unblocks all three.

**Specifically failing today:**

- `androidx.core:core-ktx:1.18.0` — AAR metadata check rejects the build because AGP 8.7.3 only supports compileSdk 35 (and the lib requires 36 + AGP 8.9.1+). [PR #28]
- `androidx.compose` BOM update — same compileSdk 36 requirement on transitive Compose libs. [PR #27]
- `androidx.lifecycle:lifecycle-runtime-ktx:2.10.0` — ships a `NonNullableMutableLiveDataDetector` lint check that hits an `IncompatibleClassChangeError` on AGP 8.7's bundled lint (Kotlin Analysis API binary mismatch — `KaCallableMemberCall` changed from class to interface). Newer AGP ships a matching lint. [PR #30]

## Bumps

| | from | to |
| --- | --- | --- |
| `com.android.tools.build:gradle` | 8.7.3 | 8.9.2 |
| Gradle wrapper | 8.9 | 8.11.1 |
| `compileSdk` | 35 | 36 |

`targetSdk` stays at 35 deliberately — that's the one that opts the app into new runtime-behavior changes, and bumping it without testing is a separate decision.

Kotlin (2.0.20) and KSP (2.0.20-1.0.25) stay put. AGP 8.9.x doesn't require a newer Kotlin.

## After this lands

The Renovate PRs will rebase against master and the AAR metadata + lint failures should clear. We may still see the lifecycle 2.10 lint issue if AGP 8.9's bundled lint isn't recent enough — if so, the next step is bumping AGP one more cycle (8.10 / 8.11) or disabling `NullSafeMutableLiveData` (we don't use LiveData anywhere — verified, the codebase is StateFlow-only).

## Test plan

- [ ] CI passes on this branch (debug + release assemble, lint, detekt, ktlint).
- [ ] Rebase Renovate PR #27, #28, #30 against master once merged; confirm they go green.
- [ ] If lifecycle 2.10 still trips lint, follow up with either AGP 8.10+ or a targeted lint-rule disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)