### PR TITLE
Quick Settings tile for play/pause (v1.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.5.3 — Quick Settings tile for play/pause
+
+Drag a **Play / Pause** tile into the system Quick Settings panel
+(swipe down twice → pencil icon → drag from "available tiles") and
+you can pause or resume Lotus without unlocking the phone.
+
+The tile reflects the current state — shows a play icon when nothing
+is playing, a pause icon while a track is going. Tapping it does the
+obvious thing.
+
+If Lotus has never started a playback session since the last reboot,
+the tile won't have anything to control yet; open the app and start
+a track once and it picks up from there.
+
 ## 1.5.2 — Sleep timer: presets and finish-current-track
 
 Two small additions to the existing sleep timer.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_005_002
-        versionName = "1.5.2-community"
+        versionCode = 1_005_003
+        versionName = "1.5.3-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,17 @@
             </intent-filter>
         </service>
 
+        <service
+            android:name=".PlayPauseTileService"
+            android:exported="true"
+            android:icon="@android:drawable/ic_media_play"
+            android:label="@string/tile_label_play"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.crashlogs"

--- a/app/src/main/java/com/dn0ne/player/PlayPauseTileService.kt
+++ b/app/src/main/java/com/dn0ne/player/PlayPauseTileService.kt
@@ -1,0 +1,86 @@
+package com.dn0ne.player
+
+import android.content.ComponentName
+import android.graphics.drawable.Icon
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import androidx.core.content.ContextCompat
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.google.common.util.concurrent.ListenableFuture
+
+class PlayPauseTileService : TileService() {
+
+    private var controllerFuture: ListenableFuture<MediaController>? = null
+    private var controller: MediaController? = null
+    private var playerListener: Player.Listener? = null
+
+    override fun onStartListening() {
+        super.onStartListening()
+        connect()
+    }
+
+    override fun onStopListening() {
+        super.onStopListening()
+        disconnect()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        val c = controller ?: return
+        val nowPlaying = c.isPlaying
+        if (nowPlaying) c.pause() else c.play()
+        // Optimistic tile update; the listener will reconcile if play() no-ops
+        // (e.g. empty queue) on the next state change.
+        renderTile(!nowPlaying)
+    }
+
+    private fun connect() {
+        val token = SessionToken(
+            applicationContext,
+            ComponentName(applicationContext, PlaybackService::class.java)
+        )
+        val future = MediaController.Builder(applicationContext, token).buildAsync()
+        controllerFuture = future
+        future.addListener(
+            {
+                if (future.isCancelled) return@addListener
+                val c = runCatching { future.get() }.getOrNull() ?: return@addListener
+                controller = c
+                val listener = object : Player.Listener {
+                    override fun onIsPlayingChanged(isPlaying: Boolean) {
+                        renderTile(isPlaying)
+                    }
+                }
+                playerListener = listener
+                c.addListener(listener)
+                renderTile(c.isPlaying)
+            },
+            ContextCompat.getMainExecutor(applicationContext)
+        )
+    }
+
+    private fun disconnect() {
+        playerListener?.let { controller?.removeListener(it) }
+        playerListener = null
+        controller?.release()
+        controller = null
+        controllerFuture?.let { MediaController.releaseFuture(it) }
+        controllerFuture = null
+    }
+
+    private fun renderTile(isPlaying: Boolean) {
+        val tile = qsTile ?: return
+        if (isPlaying) {
+            tile.icon = Icon.createWithResource(this, android.R.drawable.ic_media_pause)
+            tile.label = getString(R.string.tile_label_pause)
+            tile.state = Tile.STATE_ACTIVE
+        } else {
+            tile.icon = Icon.createWithResource(this, android.R.drawable.ic_media_play)
+            tile.label = getString(R.string.tile_label_play)
+            tile.state = Tile.STATE_INACTIVE
+        }
+        tile.updateTile()
+    }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -88,6 +88,8 @@
     <string name="stop_timer">Стоп</string>
     <string name="start_timer">Старт</string>
     <string name="finish_current_track">Доиграть текущий трек</string>
+    <string name="tile_label_play">Играть</string>
+    <string name="tile_label_pause">Пауза</string>
 
     <!-- Play queue -->
     <string name="remove_from_queue">Убрать из очереди</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -88,6 +88,8 @@
     <string name="stop_timer">Стоп</string>
     <string name="start_timer">Страт</string>
     <string name="finish_current_track">Догравати поточний трек</string>
+    <string name="tile_label_play">Грати</string>
+    <string name="tile_label_pause">Пауза</string>
 
     <!-- Play queue -->
     <string name="remove_from_queue">Прибрати з черги</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,8 @@
     <string name="stop_timer">Stop</string>
     <string name="start_timer">Start</string>
     <string name="finish_current_track">Finish current track</string>
+    <string name="tile_label_play">Play</string>
+    <string name="tile_label_pause">Pause</string>
 
     <!-- Play queue -->
     <string name="remove_from_queue">Remove from queue</string>


### PR DESCRIPTION
## Summary

Adds a system Quick Settings tile that toggles Lotus playback from anywhere — including the lock screen — without unlocking the phone or opening the app.

## How it works

`PlayPauseTileService` extends `android.service.quicksettings.TileService` and connects to the existing `PlaybackService` over Media3 `MediaController`:

- `onStartListening` (QS panel opens) → builds a `MediaController` bound to our `MediaSessionService`, registers a `Player.Listener` for `onIsPlayingChanged`, renders current state into `qsTile`.
- `onStopListening` (QS panel closes) → removes the listener, releases the controller. The tile only holds a session connection while you're actively looking at the QS panel.
- `onClick` → `c.play()` or `c.pause()` and an optimistic tile re-render; the listener will reconcile if the call no-ops (e.g. empty queue).

If `PlaybackService` isn't running yet (clean reboot, app never opened), `MediaController.Builder.buildAsync()` spins it up on first connect, same as if you launched the app.

## Why this matters

It's the smallest possible "I want to pause my music while I'm doing something else" interaction — one swipe, one tap, no app switch. Particularly useful from the lock screen.

## Files

- `PlayPauseTileService.kt` — the service implementation
- `AndroidManifest.xml` — service entry with `BIND_QUICK_SETTINGS_TILE` permission and the `QS_TILE` intent filter
- `strings.xml` (EN/RU/UK) — `tile_label_play` / `tile_label_pause`
- `CHANGELOG.md` — 1.5.3 entry
- `app/build.gradle.kts` — version bump to 1.5.3-community

No new dependencies. Uses platform drawables (`@android:drawable/ic_media_play` and `ic_media_pause`), so no bitmap or vector resources ship in the APK either.

## Test plan

- [ ] Install. Pull down QS panel → pencil/edit → "Play" tile appears in available tiles. Drag it into the active set.
- [ ] Open Lotus, start a track. Pull down QS panel: tile shows pause icon and `STATE_ACTIVE`.
- [ ] Tap the tile. Playback pauses; tile flips to play icon, `STATE_INACTIVE`.
- [ ] Tap again. Playback resumes; tile flips back.
- [ ] Lock screen: same flow works without unlocking.
- [ ] After clean reboot, with no recent playback: tap tile → service spins up, queue is empty, no crash. (Tile may briefly stay in inactive state — expected, no track loaded.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)