### PR TITLE
Loved tracks: per-track love flag + Loved smart playlist (v1.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.5.4 — Loved tracks
+
+Open the menu on any track (the dots on the right) and you'll see
+a new **Love** entry at the top. Tap it once to mark the track,
+tap it again to unmark. Loved tracks show up as a new
+**Loved tracks** section at the top of the Playlists tab, alongside
+Recently added and Random mix.
+
+The "Love" toggle is also available on the now-playing sheet menu,
+so you can mark a track without going back to the list.
+
+The state is local — nothing is sent anywhere — and it's stored in
+the same on-device database as your playlists. Existing data isn't
+touched; the database picks up a new table on first launch via a
+small Room migration.
+
 ## 1.5.3 — Quick Settings tile for play/pause
 
 Drag a **Play / Pause** tile into the system Quick Settings panel

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_005_003
-        versionName = "1.5.3-community"
+        versionCode = 1_005_004
+        versionName = "1.5.4-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/data/db/LotusDatabase.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/LotusDatabase.kt
@@ -4,13 +4,14 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 
 @Database(
-    entities = [PlaylistEntity::class, LyricsEntity::class],
-    version = 1,
+    entities = [PlaylistEntity::class, LyricsEntity::class, LovedTrackEntity::class],
+    version = 2,
     exportSchema = false,
 )
 abstract class LotusDatabase : RoomDatabase() {
     abstract fun playlistDao(): PlaylistDao
     abstract fun lyricsDao(): LyricsDao
+    abstract fun lovedTrackDao(): LovedTrackDao
 
     companion object {
         const val NAME = "lotus.db"

--- a/app/src/main/java/com/dn0ne/player/app/data/db/LovedTrackDao.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/LovedTrackDao.kt
@@ -1,0 +1,23 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface LovedTrackDao {
+
+    @Query("SELECT uri FROM loved_tracks ORDER BY added_at DESC")
+    fun observeUris(): Flow<List<String>>
+
+    @Query("SELECT EXISTS(SELECT 1 FROM loved_tracks WHERE uri = :uri)")
+    suspend fun isLoved(uri: String): Boolean
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(entity: LovedTrackEntity)
+
+    @Query("DELETE FROM loved_tracks WHERE uri = :uri")
+    suspend fun deleteByUri(uri: String)
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/db/LovedTrackEntity.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/LovedTrackEntity.kt
@@ -1,0 +1,14 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "loved_tracks")
+data class LovedTrackEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "uri")
+    val uri: String,
+    @ColumnInfo(name = "added_at")
+    val addedAt: Long,
+)

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/LovedTracksRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/LovedTracksRepository.kt
@@ -1,0 +1,10 @@
+package com.dn0ne.player.app.data.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface LovedTracksRepository {
+    fun observeLovedUris(): Flow<Set<String>>
+    suspend fun isLoved(uri: String): Boolean
+    suspend fun add(uri: String)
+    suspend fun remove(uri: String)
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/RoomLovedTracksRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/RoomLovedTracksRepository.kt
@@ -1,0 +1,24 @@
+package com.dn0ne.player.app.data.repository
+
+import com.dn0ne.player.app.data.db.LovedTrackDao
+import com.dn0ne.player.app.data.db.LovedTrackEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class RoomLovedTracksRepository(
+    private val dao: LovedTrackDao,
+) : LovedTracksRepository {
+
+    override fun observeLovedUris(): Flow<Set<String>> =
+        dao.observeUris().map { it.toSet() }
+
+    override suspend fun isLoved(uri: String): Boolean = dao.isLoved(uri)
+
+    override suspend fun add(uri: String) {
+        dao.insert(LovedTrackEntity(uri = uri, addedAt = System.currentTimeMillis()))
+    }
+
+    override suspend fun remove(uri: String) {
+        dao.deleteByUri(uri)
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -1,6 +1,8 @@
 package com.dn0ne.player.app.di
 
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.dn0ne.player.EqualizerController
 import com.dn0ne.player.app.data.LyricsReader
 import com.dn0ne.player.app.data.LyricsReaderImpl
@@ -8,6 +10,7 @@ import com.dn0ne.player.app.data.MetadataWriter
 import com.dn0ne.player.app.data.MetadataWriterImpl
 import com.dn0ne.player.app.data.SavedPlayerState
 import com.dn0ne.player.app.data.db.LotusDatabase
+import com.dn0ne.player.app.data.db.LovedTrackDao
 import com.dn0ne.player.app.data.db.LyricsDao
 import com.dn0ne.player.app.data.db.PlaylistDao
 import com.dn0ne.player.app.data.remote.lyrics.ChainLyricsProvider
@@ -19,8 +22,10 @@ import com.dn0ne.player.core.data.Settings
 import com.dn0ne.player.app.data.remote.metadata.GatedMetadataProvider
 import com.dn0ne.player.app.data.remote.metadata.MetadataProvider
 import com.dn0ne.player.app.data.remote.metadata.MusicBrainzMetadataProvider
+import com.dn0ne.player.app.data.repository.LovedTracksRepository
 import com.dn0ne.player.app.data.repository.LyricsRepository
 import com.dn0ne.player.app.data.repository.PlaylistRepository
+import com.dn0ne.player.app.data.repository.RoomLovedTracksRepository
 import com.dn0ne.player.app.data.repository.RoomLyricsRepository
 import com.dn0ne.player.app.data.repository.RoomPlaylistRepository
 import com.dn0ne.player.app.data.repository.TrackRepository
@@ -44,6 +49,19 @@ import org.koin.dsl.module
 // tiny). Picked to leave generous headroom while still catching the
 // "firehose" attack shape.
 private const val MAX_RESPONSE_BYTES = 5L * 1024 * 1024
+
+// v1 → v2: add the loved_tracks table for the Loved-tracks feature.
+// Pure additive — no existing-data transformation, safe on every device.
+private val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `loved_tracks` (" +
+                "`uri` TEXT NOT NULL, " +
+                "`added_at` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`uri`))"
+        )
+    }
+}
 
 val playerModule = module {
 
@@ -145,10 +163,13 @@ val playerModule = module {
             androidContext(),
             LotusDatabase::class.java,
             LotusDatabase.NAME,
-        ).build()
+        )
+            .addMigrations(MIGRATION_1_2)
+            .build()
     }
     single<PlaylistDao> { get<LotusDatabase>().playlistDao() }
     single<LyricsDao> { get<LotusDatabase>().lyricsDao() }
+    single<LovedTrackDao> { get<LotusDatabase>().lovedTrackDao() }
 
     single<LyricsRepository> {
         RoomLyricsRepository(dao = get())
@@ -156,6 +177,10 @@ val playerModule = module {
 
     single<PlaylistRepository> {
         RoomPlaylistRepository(dao = get())
+    }
+
+    single<LovedTracksRepository> {
+        RoomLovedTracksRepository(dao = get())
     }
 
     single<EqualizerController> {
@@ -179,6 +204,7 @@ val playerModule = module {
             lyricsRepository = get(),
             lyricsReader = get(),
             playlistRepository = get(),
+            lovedTracksRepository = get(),
             unsupportedArtworkEditFormats = get<MetadataWriter>().unsupportedArtworkEditFormats,
             settings = get(),
             musicScanner = get(),

--- a/app/src/main/java/com/dn0ne/player/app/domain/playlist/SmartPlaylists.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/playlist/SmartPlaylists.kt
@@ -51,4 +51,14 @@ object SmartPlaylists {
         val picked = tracks.shuffled(Random(seed)).take(MAX_ENTRIES)
         return Playlist(name = name, trackList = picked)
     }
+
+    fun loved(
+        tracks: List<Track>,
+        lovedUris: Set<String>,
+        name: String,
+    ): Playlist? {
+        if (lovedUris.isEmpty()) return null
+        val picked = tracks.filter { it.uri.toString() in lovedUris }
+        return if (picked.isEmpty()) null else Playlist(name = name, trackList = picked)
+    }
 }

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
@@ -230,6 +230,11 @@ fun PlayerScreen(
                 val playlistSort by viewModel.playlistSort.collectAsState()
                 val playlistSortOrder by viewModel.playlistSortOrder.collectAsState()
 
+                // Hoisted to PlayerScreen scope so the NavHost composables and
+                // PlayerSheet (rendered outside the NavHost) can all read the
+                // same Set without duplicate collection.
+                val lovedUris by viewModel.lovedUris.collectAsState()
+
                 val replaceSearchWithFilter by viewModel.settings
                     .replaceSearchWithFilter.collectAsState()
 
@@ -294,11 +299,15 @@ fun PlayerScreen(
                         // stable within a session.
                         val recentlyAddedName = stringResource(R.string.smart_recently_added)
                         val randomMixName = stringResource(R.string.smart_random_mix)
+                        val lovedName = stringResource(R.string.smart_loved)
                         val smartPlaylists = remember(
-                            trackList, recentlyAddedName, randomMixName
+                            trackList, lovedUris, recentlyAddedName, randomMixName, lovedName
                         ) {
                             val seed = System.currentTimeMillis()
                             buildList {
+                                SmartPlaylists
+                                    .loved(trackList, lovedUris, lovedName)
+                                    ?.let(::add)
                                 SmartPlaylists
                                     .recentlyAdded(trackList, recentlyAddedName)
                                     ?.let(::add)
@@ -391,6 +400,8 @@ fun PlayerScreen(
                                 navController.popBackStack(PlayerRoutes.Main, false)
                                 navController.navigate(PlayerRoutes.Playlist)
                             },
+                            lovedUris = lovedUris,
+                            onToggleLovedClick = { viewModel.toggleLoved(it) },
                             onGoToArtistClick = {
                                 viewModel.onEvent(PlayerScreenEvent.OnGoToArtistClick(it))
                                 navController.popBackStack(PlayerRoutes.Main, false)
@@ -530,6 +541,7 @@ fun PlayerScreen(
                                 listState = listState,
                                 playlist = playlist,
                                 currentTrack = currentTrack,
+                                lovedUris = lovedUris,
                                 onTrackClick = { track, playlist ->
                                     viewModel.onEvent(
                                         PlayerScreenEvent.OnTrackClick(
@@ -538,6 +550,7 @@ fun PlayerScreen(
                                         )
                                     )
                                 },
+                                onToggleLovedClick = { viewModel.toggleLoved(it) },
                                 onPlayNextClick = {
                                     viewModel.onEvent(PlayerScreenEvent.OnPlayNextClick(it))
                                 },
@@ -639,6 +652,7 @@ fun PlayerScreen(
                                 listState = listState,
                                 playlist = playlist,
                                 currentTrack = currentTrack,
+                                lovedUris = lovedUris,
                                 onRenamePlaylistClick = {
                                     showRenameSheet = true
                                 },
@@ -653,6 +667,7 @@ fun PlayerScreen(
                                         )
                                     )
                                 },
+                                onToggleLovedClick = { viewModel.toggleLoved(it) },
                                 onPlayNextClick = {
                                     viewModel.onEvent(PlayerScreenEvent.OnPlayNextClick(it))
                                 },
@@ -857,6 +872,8 @@ fun PlayerScreen(
                                         )
                                     )
                                 },
+                                lovedUris = lovedUris,
+                                onToggleLovedClick = { viewModel.toggleLoved(it) },
                                 modifier = Modifier
                                     .align(alignment = Alignment.CenterHorizontally)
                                     .fillMaxWidth()
@@ -971,6 +988,8 @@ fun MainPlayerScreen(
     onViewTrackInfoClick: (Track) -> Unit,
     onGoToAlbumClick: (Track) -> Unit,
     onGoToArtistClick: (Track) -> Unit,
+    lovedUris: Set<String>,
+    onToggleLovedClick: (Track) -> Unit,
     playlists: List<Playlist>,
     smartPlaylists: List<Playlist>,
     albumPlaylists: List<Playlist>,
@@ -1327,6 +1346,7 @@ fun MainPlayerScreen(
                     trackList(
                         trackList = trackList.filterTracks(searchFieldValue),
                         currentTrack = currentTrack,
+                        lovedUris = lovedUris,
                         onTrackClick = {
                             onTrackClick(
                                 it,
@@ -1338,6 +1358,7 @@ fun MainPlayerScreen(
                                 )
                             )
                         },
+                        onToggleLovedClick = onToggleLovedClick,
                         onPlayNextClick = onPlayNextClick,
                         onAddToQueueClick = {
                             onAddToQueueClick(listOf(it))

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
@@ -16,6 +16,7 @@ import com.dn0ne.player.app.data.LyricsReader
 import com.dn0ne.player.app.data.SavedPlayerState
 import com.dn0ne.player.app.data.remote.lyrics.LyricsProvider
 import com.dn0ne.player.app.data.remote.metadata.MetadataProvider
+import com.dn0ne.player.app.data.repository.LovedTracksRepository
 import com.dn0ne.player.app.data.repository.LyricsRepository
 import com.dn0ne.player.app.data.repository.PlaylistRepository
 import com.dn0ne.player.app.data.repository.TrackRepository
@@ -66,6 +67,7 @@ class PlayerViewModel(
     private val lyricsRepository: LyricsRepository,
     private val lyricsReader: LyricsReader,
     private val playlistRepository: PlaylistRepository,
+    private val lovedTracksRepository: LovedTracksRepository,
     private val unsupportedArtworkEditFormats: List<String>,
     val settings: Settings,
     private val musicScanner: MusicScanner,
@@ -126,6 +128,26 @@ class PlayerViewModel(
         started = SharingStarted.WhileSubscribed(5000L),
         initialValue = _playlistSortOrder.value
     )
+
+    // Loved-track URIs as a Set for O(1) "is this loved?" lookups in track
+    // rows. The DAO already orders by added_at DESC; we lose order here, but
+    // the smart-playlist builder reads the ordered Flow directly.
+    val lovedUris = lovedTracksRepository.observeLovedUris().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000L),
+        initialValue = emptySet()
+    )
+
+    fun toggleLoved(track: Track) {
+        viewModelScope.launch {
+            val uri = track.uri.toString()
+            if (lovedTracksRepository.isLoved(uri)) {
+                lovedTracksRepository.remove(uri)
+            } else {
+                lovedTracksRepository.add(uri)
+            }
+        }
+    }
 
     private val _trackList = MutableStateFlow(emptyList<Track>())
     val trackList = _trackList.stateIn(

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/TrackList.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/TrackList.kt
@@ -15,7 +15,9 @@ import com.dn0ne.player.app.domain.track.Track
 fun LazyListScope.trackList(
     trackList: List<Track>,
     currentTrack: Track?,
+    lovedUris: Set<String>,
     onTrackClick: (Track) -> Unit,
+    onToggleLovedClick: (Track) -> Unit,
     onPlayNextClick: (Track) -> Unit,
     onAddToQueueClick: (Track) -> Unit,
     onAddToPlaylistClick: (Track) -> Unit,
@@ -37,8 +39,10 @@ fun LazyListScope.trackList(
         TrackListItem(
             track = track,
             isCurrent = currentTrack == track,
+            isLoved = track.uri.toString() in lovedUris,
             onClick = { onTrackClick(track) },
             onLongClick = { onLongClick(track) },
+            onToggleLovedClick = { onToggleLovedClick(track) },
             onPlayNextClick = { onPlayNextClick(track) },
             onAddToQueueClick = { onAddToQueueClick(track) },
             onAddToPlaylistClick = { onAddToPlaylistClick(track) },
@@ -58,7 +62,9 @@ fun LazyListScope.trackList(
 fun LazyGridScope.trackList(
     trackList: List<Track>,
     currentTrack: Track?,
+    lovedUris: Set<String>,
     onTrackClick: (Track) -> Unit,
+    onToggleLovedClick: (Track) -> Unit,
     onPlayNextClick: (Track) -> Unit,
     onAddToQueueClick: (Track) -> Unit,
     onAddToPlaylistClick: (Track) -> Unit,
@@ -80,8 +86,10 @@ fun LazyGridScope.trackList(
         TrackListItem(
             track = track,
             isCurrent = currentTrack == track,
+            isLoved = track.uri.toString() in lovedUris,
             onClick = { onTrackClick(track) },
             onLongClick = { onLongClick(track) },
+            onToggleLovedClick = { onToggleLovedClick(track) },
             onPlayNextClick = { onPlayNextClick(track) },
             onAddToQueueClick = { onAddToQueueClick(track) },
             onAddToPlaylistClick = { onAddToPlaylistClick(track) },

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/TrackListItem.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/TrackListItem.kt
@@ -30,8 +30,10 @@ import com.dn0ne.player.app.domain.track.Track
 fun TrackListItem(
     track: Track,
     isCurrent: Boolean,
+    isLoved: Boolean,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
+    onToggleLovedClick: () -> Unit,
     onPlayNextClick: () -> Unit,
     onAddToQueueClick: () -> Unit,
     onAddToPlaylistClick: () -> Unit,
@@ -93,6 +95,8 @@ fun TrackListItem(
             verticalAlignment = Alignment.CenterVertically
         ) {
             TrackMenuButton(
+                isLoved = isLoved,
+                onToggleLovedClick = onToggleLovedClick,
                 onPlayNextClick = onPlayNextClick,
                 onAddToQueueClick = onAddToQueueClick,
                 onAddToPlaylistClick = onAddToPlaylistClick,

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/TrackMenu.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/TrackMenu.kt
@@ -12,6 +12,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.rounded.AddToQueue
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.FavoriteBorder
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Person
@@ -39,7 +41,9 @@ import com.dn0ne.player.R
 @Composable
 fun TrackMenu(
     isExpanded: Boolean,
+    isLoved: Boolean,
     onDismissRequest: () -> Unit,
+    onToggleLovedClick: () -> Unit,
     onPlayNextClick: () -> Unit,
     onAddToQueueClick: () -> Unit,
     onAddToPlaylistClick: () -> Unit,
@@ -56,6 +60,26 @@ fun TrackMenu(
         modifier = Modifier.width(IntrinsicSize.Min)
     ) {
         val context = LocalContext.current
+        DropdownMenuItem(
+            text = {
+                Text(
+                    text = context.resources.getString(
+                        if (isLoved) R.string.unlove_track else R.string.love_track
+                    )
+                )
+            },
+            onClick = {
+                onToggleLovedClick()
+                onDismissRequest()
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = if (isLoved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                    contentDescription = null
+                )
+            }
+        )
+
         DropdownMenuItem(
             text = {
                 Text(text = context.resources.getString(R.string.play_next))
@@ -214,6 +238,8 @@ fun TrackMenu(
 
 @Composable
 fun TrackMenuButton(
+    isLoved: Boolean,
+    onToggleLovedClick: () -> Unit,
     onPlayNextClick: () -> Unit,
     onAddToQueueClick: () -> Unit,
     onAddToPlaylistClick: () -> Unit,
@@ -243,7 +269,9 @@ fun TrackMenuButton(
 
         TrackMenu(
             isExpanded = isMenuExpanded,
+            isLoved = isLoved,
             onDismissRequest = { isMenuExpanded = false },
+            onToggleLovedClick = onToggleLovedClick,
             onPlayNextClick = onPlayNextClick,
             onAddToQueueClick = onAddToQueueClick,
             onAddToPlaylistClick = onAddToPlaylistClick,

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/PlayerSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/PlayerSheet.kt
@@ -123,6 +123,8 @@ fun PlayerSheet(
     onRemoveFromQueueClick: (Int) -> Unit,
     onReorderingQueue: (Int, Int) -> Unit,
     onTrackClick: (Track, Playlist) -> Unit,
+    lovedUris: Set<String>,
+    onToggleLovedClick: (Track) -> Unit,
     settings: Settings,
     modifier: Modifier = Modifier
 ) {
@@ -613,6 +615,12 @@ fun ExpandedPlayer(
                         }
 
                         TrackMenuButton(
+                            isLoved = playbackState.currentTrack?.let {
+                                it.uri.toString() in lovedUris
+                            } ?: false,
+                            onToggleLovedClick = {
+                                playbackState.currentTrack?.let(onToggleLovedClick)
+                            },
                             onPlayNextClick = onPlayNextClick,
                             onAddToQueueClick = onAddToQueueClick,
                             onAddToPlaylistClick = onAddToPlaylistClick,
@@ -812,6 +820,12 @@ fun ExpandedPlayer(
                                 }
 
                                 TrackMenuButton(
+                                    isLoved = playbackState.currentTrack?.let {
+                                        it.uri.toString() in lovedUris
+                                    } ?: false,
+                                    onToggleLovedClick = {
+                                        playbackState.currentTrack?.let(onToggleLovedClick)
+                                    },
                                     onPlayNextClick = onPlayNextClick,
                                     onAddToQueueClick = onAddToQueueClick,
                                     onAddToPlaylistClick = onAddToPlaylistClick,

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/PlayerSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playback/PlayerSheet.kt
@@ -308,6 +308,8 @@ fun PlayerSheet(
                     onRemoveFromQueueClick = onRemoveFromQueueClick,
                     onReorderingQueue = onReorderingQueue,
                     onTrackClick = onTrackClick,
+                    lovedUris = lovedUris,
+                    onToggleLovedClick = onToggleLovedClick,
                     modifier = Modifier.clickable(
                         onClick = {},
                         interactionSource = null,
@@ -499,6 +501,8 @@ fun ExpandedPlayer(
     onRemoveFromQueueClick: (Int) -> Unit,
     onReorderingQueue: (Int, Int) -> Unit,
     onTrackClick: (Track, Playlist) -> Unit,
+    lovedUris: Set<String>,
+    onToggleLovedClick: (Track) -> Unit,
     modifier: Modifier = Modifier
 ) {
     BackHandler {

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/MutablePlaylist.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/MutablePlaylist.kt
@@ -80,9 +80,11 @@ fun MutablePlaylist(
     listState: LazyListState = rememberLazyListState(),
     playlist: Playlist,
     currentTrack: Track?,
+    lovedUris: Set<String>,
     onRenamePlaylistClick: () -> Unit,
     onDeletePlaylistClick: () -> Unit,
     onTrackClick: (Track, Playlist) -> Unit,
+    onToggleLovedClick: (Track) -> Unit,
     onPlayNextClick: (Track) -> Unit,
     onAddToQueueClick: (List<Track>) -> Unit,
     onAddToPlaylistClick: (List<Track>) -> Unit,
@@ -454,6 +456,7 @@ fun MutablePlaylist(
                     TrackListItem(
                         track = track,
                         isCurrent = currentTrack == track,
+                        isLoved = track.uri.toString() in lovedUris,
                         onClick = {
                             onTrackClick(
                                 track,
@@ -464,6 +467,7 @@ fun MutablePlaylist(
                                 } else playlist
                             )
                         },
+                        onToggleLovedClick = { onToggleLovedClick(track) },
                         onPlayNextClick = { onPlayNextClick(track) },
                         onAddToQueueClick = { onAddToQueueClick(listOf(track)) },
                         onAddToPlaylistClick = { onAddToPlaylistClick(listOf(track)) },

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/Playlist.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/Playlist.kt
@@ -62,7 +62,9 @@ fun Playlist(
     listState: LazyListState = rememberLazyListState(),
     playlist: Playlist,
     currentTrack: Track?,
+    lovedUris: Set<String>,
     onTrackClick: (Track, Playlist) -> Unit,
+    onToggleLovedClick: (Track) -> Unit,
     onPlayNextClick: (Track) -> Unit,
     onAddToQueueClick: (List<Track>) -> Unit,
     onAddToPlaylistClick: (List<Track>) -> Unit,
@@ -360,6 +362,7 @@ fun Playlist(
             trackList(
                 trackList = playlist.trackList.filterTracks(searchFieldValue),
                 currentTrack = currentTrack,
+                lovedUris = lovedUris,
                 onTrackClick = { track ->
                     onTrackClick(
                         track,
@@ -370,6 +373,7 @@ fun Playlist(
                         } else playlist
                     )
                 },
+                onToggleLovedClick = onToggleLovedClick,
                 onPlayNextClick = onPlayNextClick,
                 onAddToQueueClick = { onAddToQueueClick(listOf(it)) },
                 onAddToPlaylistClick = { onAddToPlaylistClick(listOf(it)) },

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -55,6 +55,9 @@
     <string name="smart_playlists">Автоплейлисты</string>
     <string name="smart_recently_added">Недавно добавленные</string>
     <string name="smart_random_mix">Случайная подборка</string>
+    <string name="smart_loved">Любимые треки</string>
+    <string name="love_track">В любимые</string>
+    <string name="unlove_track">Убрать из любимых</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -55,6 +55,9 @@
     <string name="smart_playlists">Автоплейлисти</string>
     <string name="smart_recently_added">Нещодавно додані</string>
     <string name="smart_random_mix">Випадкова добірка</string>
+    <string name="smart_loved">Улюблені треки</string>
+    <string name="love_track">До улюблених</string>
+    <string name="unlove_track">Прибрати з улюблених</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,9 @@
     <string name="smart_playlists">Smart</string>
     <string name="smart_recently_added">Recently added</string>
     <string name="smart_random_mix">Random mix</string>
+    <string name="smart_loved">Loved tracks</string>
+    <string name="love_track">Love</string>
+    <string name="unlove_track">Unlove</string>
 
     <!-- Tabs' names -->
     <string name="tracks">Tracks</string>


### PR DESCRIPTION
## Summary

Adds a per-track "loved" flag and a new auto-generated **Loved tracks** smart playlist at the top of the Playlists tab.

## How it works

**Data layer**
- `LovedTrackEntity` (uri primary key, `added_at` timestamp) and `LovedTrackDao` exposing a `Flow<List<String>>` ordered newest-first.
- `RoomLovedTracksRepository` wraps the DAO and surfaces a `Flow<Set<String>>` so per-row "is this loved?" checks are O(1).
- Database schema bumped from v1 to v2 with a manual `MIGRATION_1_2` (`CREATE TABLE IF NOT EXISTS loved_tracks ...`). Pure additive migration; no existing-data transformation.

**ViewModel**
- `PlayerViewModel.lovedUris: StateFlow<Set<String>>` and `toggleLoved(track: Track)`. The toggle reads the current state, then either inserts or deletes — atomic enough for single-user UI.

**UI**
- `TrackMenu` gets a **Love** / **Unlove** entry at the top with a filled or outline heart icon depending on state.
- `TrackMenuButton`, `TrackListItem`, and the `LazyList`/`LazyGrid` `trackList` extension functions thread two new params: `lovedUris: Set<String>` and `onToggleLovedClick: (Track) -> Unit`. Membership lookup at row composition time.
- `PlayerSheet`'s two `TrackMenuButton` sites (collapsed top bar + expanded now-playing) take the same params; the heart reflects the currently-playing track.
- `PlayerScreen` hoists `lovedUris` once in the outer composable so the NavHost composables and `PlayerSheet` share a single `StateFlow` collector.

**Smart playlist**
- `SmartPlaylists.loved(tracks, lovedUris, name)` filters the MediaStore-sourced track list by the loved set. Returns `null` when the result would be empty (matching the existing builder's null-on-empty behaviour, so the section doesn't render until you've loved something).
- `PlayerScreen` prepends Loved before Recently added in the Playlists tab.

## Why per-track loved (not multi-star ratings)

The roadmap option was "ratings or loved" — went with the boolean. It's faster to interact with, simpler to explain, and feeds the smart-playlist surface without a UI for picking 3 vs 4 stars. If we want star ratings later they can sit on top of this without conflict.

## Files

- New: `LovedTrackEntity.kt`, `LovedTrackDao.kt`, `LovedTracksRepository.kt`, `RoomLovedTracksRepository.kt`
- Modified: `LotusDatabase.kt`, `PlayerModule.kt`, `SmartPlaylists.kt`, `PlayerViewModel.kt`, `PlayerScreen.kt`, `TrackMenu.kt`, `TrackListItem.kt`, `TrackList.kt`, `Playlist.kt`, `MutablePlaylist.kt`, `PlayerSheet.kt`, strings (EN/RU/UK), CHANGELOG, build.gradle.kts (version bump)

## Test plan

- [ ] Fresh install: open the app, no `Loved tracks` section appears yet.
- [ ] Open a track's dot menu → tap **Love**. Heart fills.
- [ ] Pull down the Playlists tab — `Loved tracks` appears at the top with that track in it.
- [ ] Tap the same menu again → **Unlove**. Heart hollows. Section disappears once empty.
- [ ] Open the now-playing sheet → menu shows the right state for the current track. Toggle works.
- [ ] Upgrade-from-1.5.3 path: install 1.5.3, create some playlists, then sideload this build. App opens, Room runs the v1→v2 migration, existing playlists still there, no crash.
- [ ] Force close and reopen — loved state persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)