### PR TITLE
Backup and restore: playlists + loved tracks (v1.5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.5.5 — Backup and restore
+
+A new **Backup** entry in Settings. Two buttons: save your data to a
+file, or restore from a file you saved earlier.
+
+The file is plain JSON. It contains your playlists (names and the
+tracks in them) and your loved tracks. Open it in any text editor
+if you want to see exactly what's in it. Settings, lyrics cache,
+and crash logs aren't part of it — those are easy to re-set or
+re-download.
+
+Where the file goes is up to you. The export button opens the
+system file picker; pick a folder on your device, in your cloud
+drive, or anywhere else you want it. Restore reads from the same
+kind of picker.
+
+Restore is additive on purpose. If a playlist with the same name
+already exists, the imported one is skipped. Loved tracks merge
+into your current set. Anything you've created since the backup
+stays where it is.
+
+For tracks whose files have moved or aren't on this device any
+more, the restore tells you how many couldn't be matched — those
+get skipped rather than left as dangling references.
+
 ## 1.5.4 — Loved tracks
 
 Open the menu on any track (the dots on the right) and you'll see

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_005_004
-        versionName = "1.5.4-community"
+        versionCode = 1_005_005
+        versionName = "1.5.5-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/data/backup/BackupData.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/backup/BackupData.kt
@@ -1,0 +1,52 @@
+package com.dn0ne.player.app.data.backup
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire format for the user-controlled backup file. Plain JSON so a curious
+ * user can open it in any text editor and see exactly what's in it.
+ *
+ * Each track is captured as a (uri, data-path) pair. On restore we try to
+ * resolve by URI first, then fall back to the absolute file path — handles
+ * the common "reinstalled the app, MediaStore reassigned IDs" case as long
+ * as the audio files are still in the same place on disk.
+ */
+@Serializable
+data class BackupData(
+    val schemaVersion: Int = SCHEMA_VERSION,
+    val exportedAt: Long,
+    val appVersionName: String,
+    val playlists: List<BackupPlaylist>,
+    val lovedTracks: List<BackupTrackRef>,
+) {
+    companion object {
+        const val SCHEMA_VERSION = 1
+    }
+}
+
+@Serializable
+data class BackupPlaylist(
+    val name: String,
+    val tracks: List<BackupTrackRef>,
+)
+
+@Serializable
+data class BackupTrackRef(
+    val uri: String,
+    val data: String,
+)
+
+sealed interface ExportResult {
+    data class Ok(val playlists: Int, val lovedTracks: Int) : ExportResult
+    data class Failure(val cause: Throwable) : ExportResult
+}
+
+sealed interface ImportResult {
+    data class Ok(
+        val playlistsAdded: Int,
+        val playlistsSkipped: Int,
+        val lovedTracksAdded: Int,
+        val tracksUnresolved: Int,
+    ) : ImportResult
+    data class Failure(val cause: Throwable) : ImportResult
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/backup/BackupManager.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/backup/BackupManager.kt
@@ -1,0 +1,169 @@
+package com.dn0ne.player.app.data.backup
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import com.dn0ne.player.app.data.repository.LovedTracksRepository
+import com.dn0ne.player.app.data.repository.PlaylistRepository
+import com.dn0ne.player.app.data.repository.TrackRepository
+import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.domain.track.Track
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Read/write the user-data backup file (playlists and loved tracks) over the
+ * URIs the user picks via Storage Access Framework.
+ *
+ * Import policy is *merge*, never replace:
+ *
+ * - Loved set: union with existing entries.
+ * - Playlists: add by name; if a playlist with the same name already exists,
+ *   the imported one is skipped (the result tells the caller how many).
+ *
+ * That means a restore against an empty database brings everything back, and
+ * a restore against an in-use database can't silently destroy work the user
+ * created since the backup.
+ */
+class BackupManager(
+    private val context: Context,
+    private val playlistRepository: PlaylistRepository,
+    private val lovedTracksRepository: LovedTracksRepository,
+    private val trackRepository: TrackRepository,
+    private val appVersionName: String,
+) {
+
+    private val json = Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    suspend fun export(uri: Uri): ExportResult = withContext(Dispatchers.IO) {
+        try {
+            val playlists = playlistRepository.getPlaylists().first()
+            val lovedUris = lovedTracksRepository.observeLovedUris().first()
+            val tracks = trackRepository.getTracks()
+            val byUri = tracks.associateBy { it.uri.toString() }
+
+            val backup = BackupData(
+                exportedAt = System.currentTimeMillis(),
+                appVersionName = appVersionName,
+                playlists = playlists
+                    .filter { it.name != null }
+                    .map { p ->
+                        BackupPlaylist(
+                            name = p.name!!,
+                            tracks = p.trackList.map {
+                                BackupTrackRef(
+                                    uri = it.uri.toString(),
+                                    data = it.data,
+                                )
+                            },
+                        )
+                    },
+                lovedTracks = lovedUris.mapNotNull { uri ->
+                    val track = byUri[uri] ?: return@mapNotNull BackupTrackRef(
+                        uri = uri,
+                        data = "",
+                    )
+                    BackupTrackRef(uri = uri, data = track.data)
+                },
+            )
+
+            val bytes = json.encodeToString(backup).toByteArray(Charsets.UTF_8)
+            context.contentResolver.openOutputStream(uri)?.use { it.write(bytes) }
+                ?: error("openOutputStream returned null for $uri")
+
+            ExportResult.Ok(
+                playlists = backup.playlists.size,
+                lovedTracks = backup.lovedTracks.size,
+            )
+        } catch (t: Throwable) {
+            Log.w(LOG_TAG, "Backup export failed", t)
+            ExportResult.Failure(t)
+        }
+    }
+
+    suspend fun import(uri: Uri): ImportResult = withContext(Dispatchers.IO) {
+        try {
+            val text = context.contentResolver.openInputStream(uri)?.use {
+                it.readBytes().toString(Charsets.UTF_8)
+            } ?: error("openInputStream returned null for $uri")
+            val backup = json.decodeFromString<BackupData>(text)
+
+            // Schema-version forward-compat: refuse to import a newer file
+            // than we know how to read, rather than silently dropping fields.
+            if (backup.schemaVersion > BackupData.SCHEMA_VERSION) {
+                return@withContext ImportResult.Failure(
+                    IllegalStateException(
+                        "Backup schemaVersion=${backup.schemaVersion} is newer " +
+                            "than supported (${BackupData.SCHEMA_VERSION}). Update Lotus and try again."
+                    )
+                )
+            }
+
+            val tracks = trackRepository.getTracks()
+            val byUri = tracks.associateBy { it.uri.toString() }
+            val byPath = tracks.associateBy { it.data }
+
+            val existingPlaylistNames = playlistRepository.getPlaylists()
+                .first()
+                .mapNotNull { it.name }
+                .toSet()
+
+            var unresolved = 0
+            fun resolve(ref: BackupTrackRef): Track? {
+                val match = byUri[ref.uri] ?: byPath[ref.data]
+                if (match == null) unresolved++
+                return match
+            }
+
+            // Playlists: skip name conflicts. Empty resolved-track lists are
+            // still imported so the user sees the playlist exists, even if
+            // none of the source files survived.
+            var playlistsAdded = 0
+            var playlistsSkipped = 0
+            for (bp in backup.playlists) {
+                if (bp.name in existingPlaylistNames) {
+                    playlistsSkipped++
+                    continue
+                }
+                val resolved = bp.tracks.mapNotNull(::resolve)
+                playlistRepository.insertPlaylist(
+                    Playlist(name = bp.name, trackList = resolved)
+                )
+                playlistsAdded++
+            }
+
+            // Loved: union — only add ones that resolve to a real track.
+            // Storing dangling loved URIs would just clutter the table.
+            var lovedAdded = 0
+            for (ref in backup.lovedTracks) {
+                val track = resolve(ref) ?: continue
+                val uriStr = track.uri.toString()
+                if (!lovedTracksRepository.isLoved(uriStr)) {
+                    lovedTracksRepository.add(uriStr)
+                    lovedAdded++
+                }
+            }
+
+            ImportResult.Ok(
+                playlistsAdded = playlistsAdded,
+                playlistsSkipped = playlistsSkipped,
+                lovedTracksAdded = lovedAdded,
+                tracksUnresolved = unresolved,
+            )
+        } catch (t: Throwable) {
+            Log.w(LOG_TAG, "Backup import failed", t)
+            ImportResult.Failure(t)
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "BackupManager"
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -9,6 +9,7 @@ import com.dn0ne.player.app.data.LyricsReaderImpl
 import com.dn0ne.player.app.data.MetadataWriter
 import com.dn0ne.player.app.data.MetadataWriterImpl
 import com.dn0ne.player.app.data.SavedPlayerState
+import com.dn0ne.player.app.data.backup.BackupManager
 import com.dn0ne.player.app.data.db.LotusDatabase
 import com.dn0ne.player.app.data.db.LovedTrackDao
 import com.dn0ne.player.app.data.db.LyricsDao
@@ -183,6 +184,22 @@ val playerModule = module {
         RoomLovedTracksRepository(dao = get())
     }
 
+    single<BackupManager> {
+        val ctx = androidContext()
+        val versionName = try {
+            ctx.packageManager.getPackageInfo(ctx.packageName, 0).versionName ?: "unknown"
+        } catch (t: Throwable) {
+            "unknown"
+        }
+        BackupManager(
+            context = ctx,
+            playlistRepository = get(),
+            lovedTracksRepository = get(),
+            trackRepository = get(),
+            appVersionName = versionName,
+        )
+    }
+
     single<EqualizerController> {
         EqualizerController(
             context = androidContext()
@@ -205,6 +222,7 @@ val playerModule = module {
             lyricsReader = get(),
             playlistRepository = get(),
             lovedTracksRepository = get(),
+            backupManager = get(),
             unsupportedArtworkEditFormats = get<MetadataWriter>().unsupportedArtworkEditFormats,
             settings = get(),
             musicScanner = get(),

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
@@ -965,6 +965,8 @@ fun PlayerScreen(
                     onCloseClick = {
                         viewModel.onEvent(PlayerScreenEvent.OnCloseSettingsClick)
                     },
+                    onBackupExport = { uri, cb -> viewModel.exportBackup(uri, cb) },
+                    onBackupImport = { uri, cb -> viewModel.importBackup(uri, cb) },
                     dominantColorState = dominantColorState,
                     modifier = Modifier.fillMaxSize()
                 )

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
@@ -14,6 +14,9 @@ import com.dn0ne.player.EqualizerController
 import com.dn0ne.player.R
 import com.dn0ne.player.app.data.LyricsReader
 import com.dn0ne.player.app.data.SavedPlayerState
+import com.dn0ne.player.app.data.backup.BackupManager
+import com.dn0ne.player.app.data.backup.ExportResult
+import com.dn0ne.player.app.data.backup.ImportResult
 import com.dn0ne.player.app.data.remote.lyrics.LyricsProvider
 import com.dn0ne.player.app.data.remote.metadata.MetadataProvider
 import com.dn0ne.player.app.data.repository.LovedTracksRepository
@@ -68,6 +71,7 @@ class PlayerViewModel(
     private val lyricsReader: LyricsReader,
     private val playlistRepository: PlaylistRepository,
     private val lovedTracksRepository: LovedTracksRepository,
+    private val backupManager: BackupManager,
     private val unsupportedArtworkEditFormats: List<String>,
     val settings: Settings,
     private val musicScanner: MusicScanner,
@@ -146,6 +150,18 @@ class PlayerViewModel(
             } else {
                 lovedTracksRepository.add(uri)
             }
+        }
+    }
+
+    fun exportBackup(uri: Uri, onResult: (ExportResult) -> Unit) {
+        viewModelScope.launch {
+            onResult(backupManager.export(uri))
+        }
+    }
+
+    fun importBackup(uri: Uri, onResult: (ImportResult) -> Unit) {
+        viewModelScope.launch {
+            onResult(backupManager.import(uri))
         }
     }
 

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/BackupSettings.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/BackupSettings.kt
@@ -1,0 +1,202 @@
+package com.dn0ne.player.app.presentation.components.settings
+
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBackIosNew
+import androidx.compose.material.icons.rounded.FileDownload
+import androidx.compose.material.icons.rounded.FileUpload
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import com.dn0ne.player.R
+import com.dn0ne.player.app.data.backup.ExportResult
+import com.dn0ne.player.app.data.backup.ImportResult
+import com.dn0ne.player.app.presentation.components.NoteCard
+import com.dn0ne.player.app.presentation.components.topbar.ColumnWithCollapsibleTopBar
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun BackupSettings(
+    onBackClick: () -> Unit,
+    onExport: (Uri, (ExportResult) -> Unit) -> Unit,
+    onImport: (Uri, (ImportResult) -> Unit) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var collapseFraction by remember { mutableFloatStateOf(0f) }
+
+    var pendingImportUri by remember { mutableStateOf<Uri?>(null) }
+
+    val createDocLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json")
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        onExport(uri) { result ->
+            val msg = when (result) {
+                is ExportResult.Ok -> context.resources.getString(
+                    R.string.backup_export_success,
+                    result.playlists,
+                    result.lovedTracks,
+                )
+                is ExportResult.Failure -> context.resources.getString(
+                    R.string.backup_export_failure,
+                    result.cause.localizedMessage ?: result.cause::class.simpleName.orEmpty(),
+                )
+            }
+            Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+        }
+    }
+
+    val openDocLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        pendingImportUri = uri
+    }
+
+    pendingImportUri?.let { uri ->
+        AlertDialog(
+            onDismissRequest = { pendingImportUri = null },
+            title = { Text(context.resources.getString(R.string.backup_import_confirm_title)) },
+            text = { Text(context.resources.getString(R.string.backup_import_confirm_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    pendingImportUri = null
+                    onImport(uri) { result ->
+                        val msg = when (result) {
+                            is ImportResult.Ok -> context.resources.getString(
+                                R.string.backup_import_success,
+                                result.playlistsAdded,
+                                result.playlistsSkipped,
+                                result.lovedTracksAdded,
+                                result.tracksUnresolved,
+                            )
+                            is ImportResult.Failure -> context.resources.getString(
+                                R.string.backup_import_failure,
+                                result.cause.localizedMessage ?: result.cause::class.simpleName.orEmpty(),
+                            )
+                        }
+                        Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+                    }
+                }) {
+                    Text(context.resources.getString(R.string.backup_import_confirm_yes))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingImportUri = null }) {
+                    Text(context.resources.getString(R.string.cancel))
+                }
+            },
+        )
+    }
+
+    ColumnWithCollapsibleTopBar(
+        topBarContent = {
+            IconButton(
+                onClick = onBackClick,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.ArrowBackIosNew,
+                    contentDescription = context.resources.getString(R.string.back),
+                )
+            }
+            Text(
+                text = context.resources.getString(R.string.backup),
+                fontSize = lerp(
+                    MaterialTheme.typography.titleLarge.fontSize,
+                    MaterialTheme.typography.displaySmall.fontSize,
+                    collapseFraction,
+                ),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(horizontal = 16.dp),
+            )
+        },
+        collapseFraction = { collapseFraction = it },
+        contentPadding = PaddingValues(horizontal = 28.dp),
+        contentHorizontalAlignment = Alignment.CenterHorizontally,
+        contentVerticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .safeDrawingPadding(),
+    ) {
+        NoteCard(
+            label = context.resources.getString(R.string.backup_what_is_included),
+            leadingIcon = Icons.Rounded.FileDownload,
+        ) {
+            Text(text = context.resources.getString(R.string.backup_what_is_included_body))
+        }
+
+        Spacer(Modifier.height(4.dp))
+
+        FilledTonalButton(
+            onClick = { createDocLauncher.launch(suggestedBackupFileName()) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.FileDownload,
+                contentDescription = null,
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(context.resources.getString(R.string.backup_export))
+        }
+
+        FilledTonalButton(
+            onClick = { openDocLauncher.launch(arrayOf("application/json", "*/*")) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.FileUpload,
+                contentDescription = null,
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(context.resources.getString(R.string.backup_import))
+        }
+
+        NoteCard(
+            label = context.resources.getString(R.string.backup_import_policy_title),
+            leadingIcon = Icons.Rounded.FileUpload,
+        ) {
+            Text(text = context.resources.getString(R.string.backup_import_policy_body))
+        }
+    }
+}
+
+private fun suggestedBackupFileName(): String {
+    val ts = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
+    return "lotus-backup-$ts.json"
+}

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingsSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingsSheet.kt
@@ -18,9 +18,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
+import android.net.Uri
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
 import androidx.compose.material.icons.rounded.ArrowBackIosNew
+import androidx.compose.material.icons.rounded.Backup
 import androidx.compose.material.icons.rounded.ColorLens
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Lock
@@ -49,6 +51,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.dn0ne.player.R
+import com.dn0ne.player.app.data.backup.ExportResult
+import com.dn0ne.player.app.data.backup.ImportResult
 import com.dn0ne.player.app.presentation.components.topbar.ColumnWithCollapsibleTopBar
 import com.kmpalette.DominantColorState
 import kotlinx.serialization.Serializable
@@ -61,6 +65,8 @@ fun SettingsSheet(
     onPlaylistPick: () -> Unit,
     onScanFoldersClick: () -> Unit,
     onCloseClick: () -> Unit,
+    onBackupExport: (Uri, (ExportResult) -> Unit) -> Unit,
+    onBackupImport: (Uri, (ImportResult) -> Unit) -> Unit,
     dominantColorState: DominantColorState<ImageBitmap>,
     modifier: Modifier = Modifier
 ) {
@@ -204,6 +210,14 @@ fun SettingsSheet(
                                     onClick = {
                                         navController.navigate(SettingsRoutes.Privacy)
                                     }
+                                ),
+                                SettingsItem(
+                                    title = context.resources.getString(R.string.backup),
+                                    supportingText = context.resources.getString(R.string.backup_supporting_text),
+                                    icon = Icons.Rounded.Backup,
+                                    onClick = {
+                                        navController.navigate(SettingsRoutes.Backup)
+                                    }
                                 )
                             )
                         }
@@ -304,6 +318,17 @@ fun SettingsSheet(
                     )
                 }
 
+                composable<SettingsRoutes.Backup> {
+                    BackupSettings(
+                        onBackClick = {
+                            navController.navigateUp()
+                        },
+                        onExport = onBackupExport,
+                        onImport = onBackupImport,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+
                 composable<SettingsRoutes.About> {
                     AboutPage(
                         onBackClick = {
@@ -342,6 +367,9 @@ sealed interface SettingsRoutes {
 
     @Serializable
     data object Privacy : SettingsRoutes
+
+    @Serializable
+    data object Backup : SettingsRoutes
 
     @Serializable
     data object About : SettingsRoutes

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -59,6 +59,23 @@
     <string name="love_track">В любимые</string>
     <string name="unlove_track">Убрать из любимых</string>
 
+    <!-- Backup -->
+    <string name="backup">Резервная копия</string>
+    <string name="backup_supporting_text">Сохраните плейлисты и любимые треки в файл, которым управляете вы. Восстановите позже.</string>
+    <string name="backup_export">Сохранить копию</string>
+    <string name="backup_import">Восстановить из файла</string>
+    <string name="backup_what_is_included">Что в файле</string>
+    <string name="backup_what_is_included_body">Плейлисты (названия и треки) и любимые треки. Обычный JSON — откройте в любом текстовом редакторе, чтобы увидеть содержимое. Настройки, кэш текстов и журналы сбоев не включены.</string>
+    <string name="backup_import_policy_title">Как работает восстановление</string>
+    <string name="backup_import_policy_body">Восстановление дополняет данные. Существующие плейлисты с теми же именами сохраняются — добавляются только новые. Любимые треки объединяются. Записи, чьи файлы недоступны, пропускаются.</string>
+    <string name="backup_import_confirm_title">Восстановить из этого файла?</string>
+    <string name="backup_import_confirm_body">Lotus прочитает выбранный файл и добавит новые записи. Ничего из имеющегося на устройстве не удаляется.</string>
+    <string name="backup_import_confirm_yes">Восстановить</string>
+    <string name="backup_export_success">Сохранено: %1$d плейлистов и %2$d любимых треков.</string>
+    <string name="backup_export_failure">Не удалось сохранить копию: %1$s</string>
+    <string name="backup_import_success">Добавлено %1$d плейлистов, пропущено по совпадению имён %2$d, любимых добавлено %3$d. %4$d записей не нашлись среди локальных файлов.</string>
+    <string name="backup_import_failure">Не удалось прочитать копию: %1$s</string>
+
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>
     <string name="albums">Альбомы</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -59,6 +59,23 @@
     <string name="love_track">До улюблених</string>
     <string name="unlove_track">Прибрати з улюблених</string>
 
+    <!-- Backup -->
+    <string name="backup">Резервна копія</string>
+    <string name="backup_supporting_text">Збережіть плейлісти та улюблені треки у файл, яким керуєте ви. Поверніть їх пізніше.</string>
+    <string name="backup_export">Зберегти копію</string>
+    <string name="backup_import">Відновити з файлу</string>
+    <string name="backup_what_is_included">Що у файлі</string>
+    <string name="backup_what_is_included_body">Плейлісти (назви та треки в них) і улюблені треки. Звичайний JSON — відкрийте в будь-якому текстовому редакторі. Налаштування, кеш текстів і журнали збоїв не включено.</string>
+    <string name="backup_import_policy_title">Як працює відновлення</string>
+    <string name="backup_import_policy_body">Відновлення доповнює дані. Існуючі плейлісти з такими ж назвами зберігаються — додаються лише нові. Улюблені треки об\'єднуються. Записи, чиї файли недоступні, пропускаються.</string>
+    <string name="backup_import_confirm_title">Відновити з цього файлу?</string>
+    <string name="backup_import_confirm_body">Lotus прочитає обраний файл і додасть нові записи. Ніщо з наявного на пристрої не видаляється.</string>
+    <string name="backup_import_confirm_yes">Відновити</string>
+    <string name="backup_export_success">Збережено: %1$d плейлістів і %2$d улюблених треків.</string>
+    <string name="backup_export_failure">Не вдалося зберегти копію: %1$s</string>
+    <string name="backup_import_success">Додано %1$d плейлістів, пропущено за збігом імен %2$d, улюблених додано %3$d. %4$d записів не знайшлися серед локальних файлів.</string>
+    <string name="backup_import_failure">Не вдалося прочитати копію: %1$s</string>
+
     <!-- Tabs' names -->
     <string name="tracks">Треки</string>
     <string name="albums">Альбоми</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,23 @@
     <string name="love_track">Love</string>
     <string name="unlove_track">Unlove</string>
 
+    <!-- Backup -->
+    <string name="backup">Backup</string>
+    <string name="backup_supporting_text">Save your playlists and loved tracks to a file you control. Bring them back later.</string>
+    <string name="backup_export">Save backup</string>
+    <string name="backup_import">Restore from file</string>
+    <string name="backup_what_is_included">What\'s in the file</string>
+    <string name="backup_what_is_included_body">Your playlists (names + the tracks in them) and your loved tracks. Plain JSON — open it in any text editor if you want to see exactly what\'s saved. Settings, lyrics cache, and crash logs aren\'t included.</string>
+    <string name="backup_import_policy_title">How restore works</string>
+    <string name="backup_import_policy_body">Restore is additive. Existing playlists with the same name are kept; only new ones are added. Loved tracks are merged. Tracks whose files have moved off the device are skipped.</string>
+    <string name="backup_import_confirm_title">Restore from this file?</string>
+    <string name="backup_import_confirm_body">Lotus will read the file you picked and add anything new to your library. Nothing already on this device is removed.</string>
+    <string name="backup_import_confirm_yes">Restore</string>
+    <string name="backup_export_success">Saved %1$d playlists and %2$d loved tracks.</string>
+    <string name="backup_export_failure">Couldn\'t save backup: %1$s</string>
+    <string name="backup_import_success">Added %1$d playlists, skipped %2$d already-named, added %3$d loved tracks. %4$d entries didn\'t match any local file.</string>
+    <string name="backup_import_failure">Couldn\'t read backup: %1$s</string>
+
     <!-- Tabs' names -->
     <string name="tracks">Tracks</string>
     <string name="albums">Albums</string>


### PR DESCRIPTION
## Summary

A new **Backup** entry in Settings. Two buttons: save your data to a file, or restore from a file you saved earlier. The file is plain JSON, the location is whatever the system picker lets you pick, the contents are exactly your user-curated data — playlists and loved tracks.

## What's in the file

- User playlists (names + the tracks in them)
- Loved track URIs

Settings, lyrics cache, and crash logs are deliberately not in there. They're easy to reset or re-download and would bloat the file without buying anything.

## How tracks are captured

Each track ref is a `(uri, data)` pair — the MediaStore URI and the absolute file path. On restore we resolve by URI first, fall back to path. Handles the common "reinstalled the app, MediaStore IDs shifted" case as long as files are still in the same location on disk. Files that have moved or been deleted get a count back to the user — they're skipped rather than left as dangling refs.

## Restore policy

Merge, never replace:

- Loved tracks: union with the existing set.
- Playlists: add by name; if a same-named playlist already exists, the imported one is skipped and counted.
- Unresolved refs: skipped, counted.

Restoring against an empty database brings everything back; restoring against an in-use database can't silently destroy anything you've created since.

## UI

- `Settings → Backup` — same SettingsItem style as the existing Privacy / Lyrics entries, with `Icons.Rounded.Backup`.
- Two `FilledTonalButton`s. Export uses `CreateDocument("application/json")` with a date-stamped suggested name (`lotus-backup-YYYYMMDD-HHMMSS.json`). Import uses `OpenDocument` with `application/json` + `*/*` mime types.
- Restore goes through an `AlertDialog` so a stray pick can't add stuff to your library.
- Result is a `Toast` (existing `SnackbarController` only takes a `StringRes`, not formatted strings; the existing M3U export uses Toasts for the same reason).

## Forward compat

`schemaVersion: Int = 1` on every export. Import refuses files whose `schemaVersion` is higher than the running app supports, with a clear error — so a future format change won't silently drop fields on an older build.

## Files

- New: `BackupData.kt`, `BackupManager.kt`, `BackupSettings.kt`
- Modified: `PlayerModule.kt` (DI for `BackupManager`), `PlayerViewModel.kt` (`exportBackup` / `importBackup`), `SettingsSheet.kt` (entry + route + callbacks), `PlayerScreen.kt` (passes the callbacks), strings (EN/RU/UK), CHANGELOG, version bump.

## Test plan

- [ ] Create a playlist, love a couple of tracks. Settings → Backup → Save backup → pick a folder. File appears with the suggested name.
- [ ] Open the file in a text viewer. Schema/playlists/loved sections look right.
- [ ] Delete the playlist + unlove the tracks. Settings → Backup → Restore from file → confirm. Playlist comes back, loves come back, Toast reports the counts.
- [ ] Try to re-restore the same file. Toast reports playlists skipped and 0 loved added (already present).
- [ ] Restore with **no** match (e.g. fresh install on a different device): Toast reports `tracksUnresolved` count > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)