### PR TITLE
feat(stats): record play/skip counts and listening time

### DIFF
--- a/app/src/main/java/com/dn0ne/player/PlayCountTracker.kt
+++ b/app/src/main/java/com/dn0ne/player/PlayCountTracker.kt
@@ -1,0 +1,107 @@
+package com.dn0ne.player
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import com.dn0ne.player.app.data.repository.TrackStatsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+// Tracks per-track play/skip counts and total listening time. The two paths
+// are independent on purpose:
+//   - Listening time accumulates as wallclock during playing periods and is
+//     flushed on pause / track change / queue end.
+//   - Play vs skip is a single position read at the moment of transition,
+//     using oldPosition.positionMs / outgoing track duration ≥ 0.5.
+// This keeps total_listening_ms owned by one path so transitions never
+// double-count what checkpoints already wrote.
+class PlayCountTracker(
+    private val player: Player,
+    private val repository: TrackStatsRepository,
+    private val scope: CoroutineScope,
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+) : Player.Listener {
+
+    private data class Session(val uri: String, var startedAt: Long?)
+
+    private var current: Session? = null
+    private val window = Timeline.Window()
+
+    override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+        // onPositionDiscontinuity has already finalized the outgoing track
+        // for index-changing transitions. Open a fresh session for the new
+        // item; if the player is already playing, start the listening clock.
+        current = mediaItem?.mediaId?.let {
+            Session(uri = it, startedAt = if (player.isPlaying) nowMs() else null)
+        }
+    }
+
+    override fun onPositionDiscontinuity(
+        oldPosition: Player.PositionInfo,
+        newPosition: Player.PositionInfo,
+        reason: Int,
+    ) {
+        if (oldPosition.mediaItemIndex == newPosition.mediaItemIndex) return
+        val outgoing = current ?: return
+        flushListening(outgoing)
+        outgoing.startedAt = null
+
+        val durationMs = readDuration(oldPosition.mediaItemIndex)
+        val isPlay = if (durationMs != null && durationMs > 0) {
+            oldPosition.positionMs.toDouble() / durationMs >= 0.5
+        } else {
+            // Unknown duration (streaming, unfinished metadata): fall back
+            // to "did we listen for at least 30s." Local audio shouldn't hit
+            // this branch.
+            oldPosition.positionMs >= 30_000L
+        }
+
+        val uri = outgoing.uri
+        val now = nowMs()
+        scope.launch { repository.recordEvent(uri = uri, isPlay = isPlay, now = now) }
+    }
+
+    override fun onPlaybackStateChanged(playbackState: Int) {
+        if (playbackState != Player.STATE_ENDED) return
+        // Queue ran out naturally — the still-current track played to its
+        // end. No transition fires for this case, so handle it here.
+        val outgoing = current ?: return
+        flushListening(outgoing)
+        outgoing.startedAt = null
+        val uri = outgoing.uri
+        val now = nowMs()
+        scope.launch { repository.recordEvent(uri = uri, isPlay = true, now = now) }
+    }
+
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        val session = current ?: return
+        if (isPlaying) {
+            session.startedAt = nowMs()
+        } else {
+            flushListening(session)
+            session.startedAt = null
+        }
+    }
+
+    fun flush() {
+        val session = current ?: return
+        flushListening(session)
+        session.startedAt = null
+    }
+
+    private fun flushListening(session: Session) {
+        val startedAt = session.startedAt ?: return
+        val delta = (nowMs() - startedAt).coerceAtLeast(0L)
+        if (delta <= 0L) return
+        val uri = session.uri
+        scope.launch { repository.addListeningMs(uri = uri, ms = delta) }
+    }
+
+    private fun readDuration(mediaItemIndex: Int): Long? {
+        val timeline = player.currentTimeline
+        if (mediaItemIndex < 0 || mediaItemIndex >= timeline.windowCount) return null
+        return runCatching { timeline.getWindow(mediaItemIndex, window).durationMs }
+            .getOrNull()
+            ?.takeIf { it > 0 }
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/PlaybackService.kt
+++ b/app/src/main/java/com/dn0ne/player/PlaybackService.kt
@@ -18,7 +18,11 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
+import com.dn0ne.player.app.data.repository.TrackStatsRepository
 import com.dn0ne.player.core.data.Settings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -211,6 +215,9 @@ class EqualizerController(context: Context) {
 class PlaybackService : MediaSessionService() {
     private var mediaSession: MediaSession? = null
     private val equalizerController = get<EqualizerController>()
+    private val trackStatsRepository = get<TrackStatsRepository>()
+    private val statsScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var playCountTracker: PlayCountTracker? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -237,6 +244,12 @@ class PlaybackService : MediaSessionService() {
                 }
             }
         })
+
+        playCountTracker = PlayCountTracker(
+            player = player,
+            repository = trackStatsRepository,
+            scope = statsScope,
+        ).also { player.addListener(it) }
 
         SleepTimer.addOnFinishCallback {
             if (SleepTimer.finishLastTrack.value && player.isPlaying) {
@@ -289,6 +302,11 @@ class PlaybackService : MediaSessionService() {
     }
 
     override fun onDestroy() {
+        // Capture any in-flight listening time before the player is gone.
+        // Don't cancel statsScope — it would kill the just-launched flush
+        // before it hits the DB. The IO dispatcher coroutine completes on
+        // its own.
+        playCountTracker?.flush()
         equalizerController.releaseEqualizer()
         SleepTimer.stop()
         mediaSession?.run {

--- a/app/src/main/java/com/dn0ne/player/app/data/db/LotusDatabase.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/LotusDatabase.kt
@@ -4,14 +4,20 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 
 @Database(
-    entities = [PlaylistEntity::class, LyricsEntity::class, LovedTrackEntity::class],
-    version = 2,
+    entities = [
+        PlaylistEntity::class,
+        LyricsEntity::class,
+        LovedTrackEntity::class,
+        TrackStatsEntity::class,
+    ],
+    version = 3,
     exportSchema = false,
 )
 abstract class LotusDatabase : RoomDatabase() {
     abstract fun playlistDao(): PlaylistDao
     abstract fun lyricsDao(): LyricsDao
     abstract fun lovedTrackDao(): LovedTrackDao
+    abstract fun trackStatsDao(): TrackStatsDao
 
     companion object {
         const val NAME = "lotus.db"

--- a/app/src/main/java/com/dn0ne/player/app/data/db/TrackStatsDao.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/TrackStatsDao.kt
@@ -1,0 +1,51 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+interface TrackStatsDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertIfMissing(entity: TrackStatsEntity)
+
+    @Query(
+        "UPDATE track_stats " +
+            "SET play_count = play_count + :playInc, " +
+            "skip_count = skip_count + :skipInc, " +
+            "first_played_at = COALESCE(first_played_at, :now), " +
+            "last_played_at = MAX(COALESCE(last_played_at, 0), :now) " +
+            "WHERE uri = :uri"
+    )
+    suspend fun applyTally(uri: String, playInc: Int, skipInc: Int, now: Long)
+
+    @Query(
+        "UPDATE track_stats " +
+            "SET total_listening_ms = total_listening_ms + :ms " +
+            "WHERE uri = :uri"
+    )
+    suspend fun applyListeningMs(uri: String, ms: Long)
+
+    @Transaction
+    suspend fun recordEvent(uri: String, isPlay: Boolean, now: Long) {
+        insertIfMissing(TrackStatsEntity(uri = uri))
+        applyTally(
+            uri = uri,
+            playInc = if (isPlay) 1 else 0,
+            skipInc = if (isPlay) 0 else 1,
+            now = now,
+        )
+    }
+
+    @Transaction
+    suspend fun addListeningMs(uri: String, ms: Long) {
+        insertIfMissing(TrackStatsEntity(uri = uri))
+        applyListeningMs(uri = uri, ms = ms)
+    }
+
+    @Query("DELETE FROM track_stats")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/db/TrackStatsEntity.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/TrackStatsEntity.kt
@@ -1,0 +1,22 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "track_stats")
+data class TrackStatsEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "uri")
+    val uri: String,
+    @ColumnInfo(name = "play_count")
+    val playCount: Int = 0,
+    @ColumnInfo(name = "skip_count")
+    val skipCount: Int = 0,
+    @ColumnInfo(name = "total_listening_ms")
+    val totalListeningMs: Long = 0,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long? = null,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long? = null,
+)

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/RoomTrackStatsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/RoomTrackStatsRepository.kt
@@ -1,0 +1,20 @@
+package com.dn0ne.player.app.data.repository
+
+import com.dn0ne.player.app.data.db.TrackStatsDao
+
+class RoomTrackStatsRepository(
+    private val dao: TrackStatsDao,
+) : TrackStatsRepository {
+
+    override suspend fun recordEvent(uri: String, isPlay: Boolean, now: Long) {
+        dao.recordEvent(uri = uri, isPlay = isPlay, now = now)
+    }
+
+    override suspend fun addListeningMs(uri: String, ms: Long) {
+        dao.addListeningMs(uri = uri, ms = ms)
+    }
+
+    override suspend fun clearAll() {
+        dao.clearAll()
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/TrackStatsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/TrackStatsRepository.kt
@@ -1,0 +1,7 @@
+package com.dn0ne.player.app.data.repository
+
+interface TrackStatsRepository {
+    suspend fun recordEvent(uri: String, isPlay: Boolean, now: Long)
+    suspend fun addListeningMs(uri: String, ms: Long)
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -14,6 +14,7 @@ import com.dn0ne.player.app.data.db.LotusDatabase
 import com.dn0ne.player.app.data.db.LovedTrackDao
 import com.dn0ne.player.app.data.db.LyricsDao
 import com.dn0ne.player.app.data.db.PlaylistDao
+import com.dn0ne.player.app.data.db.TrackStatsDao
 import com.dn0ne.player.app.data.remote.lyrics.ChainLyricsProvider
 import com.dn0ne.player.app.data.remote.lyrics.GatedLyricsProvider
 import com.dn0ne.player.app.data.remote.lyrics.LrclibLyricsProvider
@@ -29,8 +30,10 @@ import com.dn0ne.player.app.data.repository.PlaylistRepository
 import com.dn0ne.player.app.data.repository.RoomLovedTracksRepository
 import com.dn0ne.player.app.data.repository.RoomLyricsRepository
 import com.dn0ne.player.app.data.repository.RoomPlaylistRepository
+import com.dn0ne.player.app.data.repository.RoomTrackStatsRepository
 import com.dn0ne.player.app.data.repository.TrackRepository
 import com.dn0ne.player.app.data.repository.TrackRepositoryImpl
+import com.dn0ne.player.app.data.repository.TrackStatsRepository
 import com.dn0ne.player.app.presentation.PlayerViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -59,6 +62,27 @@ private val MIGRATION_1_2 = object : Migration(1, 2) {
             "CREATE TABLE IF NOT EXISTS `loved_tracks` (" +
                 "`uri` TEXT NOT NULL, " +
                 "`added_at` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`uri`))"
+        )
+    }
+}
+
+// v2 → v3: add track_stats for play/skip counts and listening time. Also
+// purely additive; backfilled to empty (no historical events to recover).
+// Column definitions must match exactly what Room generates from
+// TrackStatsEntity — Room hashes the schema on open and rejects mismatches.
+// No DEFAULT clauses here since the entity doesn't declare @ColumnInfo
+// defaultValue; Kotlin-side defaults handle that at the entity level.
+private val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `track_stats` (" +
+                "`uri` TEXT NOT NULL, " +
+                "`play_count` INTEGER NOT NULL, " +
+                "`skip_count` INTEGER NOT NULL, " +
+                "`total_listening_ms` INTEGER NOT NULL, " +
+                "`first_played_at` INTEGER, " +
+                "`last_played_at` INTEGER, " +
                 "PRIMARY KEY(`uri`))"
         )
     }
@@ -165,12 +189,13 @@ val playerModule = module {
             LotusDatabase::class.java,
             LotusDatabase.NAME,
         )
-            .addMigrations(MIGRATION_1_2)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
             .build()
     }
     single<PlaylistDao> { get<LotusDatabase>().playlistDao() }
     single<LyricsDao> { get<LotusDatabase>().lyricsDao() }
     single<LovedTrackDao> { get<LotusDatabase>().lovedTrackDao() }
+    single<TrackStatsDao> { get<LotusDatabase>().trackStatsDao() }
 
     single<LyricsRepository> {
         RoomLyricsRepository(dao = get())
@@ -182,6 +207,10 @@ val playerModule = module {
 
     single<LovedTracksRepository> {
         RoomLovedTracksRepository(dao = get())
+    }
+
+    single<TrackStatsRepository> {
+        RoomTrackStatsRepository(dao = get())
     }
 
     single<BackupManager> {


### PR DESCRIPTION
## Summary
- Adds `track_stats` Room table (`uri` PK) with `play_count`, `skip_count`, `total_listening_ms`, `first_played_at`, `last_played_at`. Schema v2 → v3 with an additive migration mirroring `MIGRATION_1_2`.
- New `PlayCountTracker` (`Player.Listener`) wires into `PlaybackService` and writes via a new `TrackStatsRepository`.
- Two independent paths into the same row:
  - **Listening time** accumulates as wallclock during playing periods and is flushed on pause / track change / queue end / service destroy. Owned exclusively by this path so transitions never double-count it.
  - **Play vs skip** is a single position read at transition: if `oldPosition.positionMs / outgoing window duration >= 0.5` it's a play, otherwise a skip. `STATE_ENDED` (queue exhausted) is treated as a play.
- DAO exposes `clearAll()` so the future tracking-toggle can wipe rows when disabled.

## Scope
This is infra-only — no UI, no Settings entry, no backup integration yet. The stats screen and tracking-toggle will land in a follow-up PR. Per release policy, no version bump (no APK-visible change).

## Test plan
- [ ] CI build + unit tests pass
- [ ] Install on device, play a full track → `track_stats` row gains `play_count=1`, non-zero `total_listening_ms`, populated `first_played_at` / `last_played_at`
- [ ] Skip a track before 50% → `skip_count` increments, `play_count` stays
- [ ] Skip after 50% → `play_count` increments
- [ ] Pause mid-track for a while, resume, skip → `total_listening_ms` reflects only playing time
- [ ] Fresh install → migration creates `track_stats`; upgrade install (existing v2 db) → migration adds `track_stats` without touching other tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)