### PR TITLE
feat(stats): finish play-count infra to spec (v1.5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.5.6 — Listening stats (groundwork)
+
+Lotus now records how often you play and skip each track, and how long
+you've spent listening. The numbers live only on this device, in the
+same SQLite database as your playlists. There's no stats screen yet —
+that's the next release — but the recording happens in the background
+from this version on, so by the time the screen lands you'll already
+have data to look at.
+
+A track counts as a *play* once you cross its halfway mark. Move on
+before that and it's a *skip*. Seeking back after you've crossed the
+halfway mark doesn't undo the play. Live streams and broken-metadata
+files (where the track length is unknown) are skipped over silently.
+
+Settings → Privacy has a new **Record listening stats** toggle. It's
+on by default. Flipping it off does both halves of "stop tracking":
+new events stop being written, and the existing counts are dropped.
+No half-state.
+
+Backup files (the export/restore feature from 1.5.5) now carry your
+listening stats too. Restore merges them carefully: re-importing the
+same backup is a no-op, and importing an older backup never rolls back
+counts you've earned since. If you have the privacy toggle off when you
+restore, the listening-stats portion is skipped silently and the rest
+of the backup imports as before.
+
 ## 1.5.5 — Backup and restore
 
 A new **Backup** entry in Settings. Two buttons: save your data to a

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ in [CHANGELOG.md](CHANGELOG.md); summaries below are cumulative.
   lists at the top: **Recently added** (files modified within the last
   30 days) and **Random mix** (up to 100 tracks shuffled). They feel
   like any other playlist — tap to open, play from, or export to M3U.
+- **Listening stats (groundwork)** — Lotus now records play count, skip
+  count, and listening time per track in the on-device database. Counts
+  follow the natural intuition: a play is +1 once you cross the halfway
+  mark of the track; a skip is +1 if you move on before that. The stats
+  screen that visualises this is the next planned release; for now it's
+  silent infrastructure that survives backup/restore and respects the
+  privacy toggle below.
 
 ### Privacy and security
 
@@ -121,6 +128,10 @@ in [CHANGELOG.md](CHANGELOG.md); summaries below are cumulative.
 - **In-app privacy disclosure** — Settings → Privacy lists exactly what
   leaves the device (and what each upstream service sees) versus what
   stays local. No hidden network behavior.
+- **Listening-stats opt-out** — Settings → Privacy has a "Record listening
+  stats" toggle. Flipping it off means both halves: stop counting *and*
+  erase what's already been counted. On by default, but a single tap
+  drops the table so disabling doesn't leave stale rows behind.
 
 ### Housekeeping
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_005_005
-        versionName = "1.5.5-community"
+        versionCode = 1_005_006
+        versionName = "1.5.6-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/PlayCountTracker.kt
+++ b/app/src/main/java/com/dn0ne/player/PlayCountTracker.kt
@@ -5,35 +5,48 @@ import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import com.dn0ne.player.app.data.repository.TrackStatsRepository
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-// Tracks per-track play/skip counts and total listening time. The two paths
-// are independent on purpose:
-//   - Listening time accumulates as wallclock during playing periods and is
-//     flushed on pause / track change / queue end.
-//   - Play vs skip is a single position read at the moment of transition,
-//     using oldPosition.positionMs / outgoing track duration ≥ 0.5.
-// This keeps total_listening_ms owned by one path so transitions never
-// double-count what checkpoints already wrote.
+// Records per-track play/skip counts and listening-ms via a Player.Listener.
+//
+// Two independent paths into track_stats:
+//   - addListenedMs gets called by a 10 s checkpoint while playing and at
+//     the close-out of every transition. The delta is *position-progress*
+//     (currentPositionMs - lastFlushedPositionMs), clamped to >= 0, so
+//     replaying the same section doesn't double-count.
+//   - recordPlay / recordSkip is decided once at the close-out using a
+//     high-water mark (maxReachedPositionMs >= duration/2). Seeking back
+//     after crossing 50 % doesn't undo the play.
+//
+// The tracking toggle gates DAO writes only — in-memory state keeps moving
+// when off, so flipping back on doesn't flush a giant catch-up delta.
 class PlayCountTracker(
     private val player: Player,
     private val repository: TrackStatsRepository,
     private val scope: CoroutineScope,
+    private val isTrackingEnabled: () -> Boolean = { true },
     private val nowMs: () -> Long = { System.currentTimeMillis() },
+    private val checkpointIntervalMs: Long = CHECKPOINT_INTERVAL_MS,
 ) : Player.Listener {
 
-    private data class Session(val uri: String, var startedAt: Long?)
+    private data class Session(
+        val uri: String,
+        var lastFlushedPositionMs: Long = 0L,
+        var maxReachedPositionMs: Long = 0L,
+    )
 
     private var current: Session? = null
     private val window = Timeline.Window()
+    private var checkpointJob: Job? = null
 
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-        // onPositionDiscontinuity has already finalized the outgoing track
-        // for index-changing transitions. Open a fresh session for the new
-        // item; if the player is already playing, start the listening clock.
-        current = mediaItem?.mediaId?.let {
-            Session(uri = it, startedAt = if (player.isPlaying) nowMs() else null)
-        }
+        // The outgoing item was finalized in onPositionDiscontinuity for
+        // index-changing transitions; here we just open a fresh session.
+        current = mediaItem?.mediaId?.let { Session(uri = it) }
+        if (player.isPlaying && current != null) startCheckpointLoop()
     }
 
     override fun onPositionDiscontinuity(
@@ -43,65 +56,102 @@ class PlayCountTracker(
     ) {
         if (oldPosition.mediaItemIndex == newPosition.mediaItemIndex) return
         val outgoing = current ?: return
-        flushListening(outgoing)
-        outgoing.startedAt = null
-
-        val durationMs = readDuration(oldPosition.mediaItemIndex)
-        val isPlay = if (durationMs != null && durationMs > 0) {
-            oldPosition.positionMs.toDouble() / durationMs >= 0.5
-        } else {
-            // Unknown duration (streaming, unfinished metadata): fall back
-            // to "did we listen for at least 30s." Local audio shouldn't hit
-            // this branch.
-            oldPosition.positionMs >= 30_000L
-        }
-
-        val uri = outgoing.uri
-        val now = nowMs()
-        scope.launch { repository.recordEvent(uri = uri, isPlay = isPlay, now = now) }
+        finalizeOutgoing(
+            session = outgoing,
+            finalPositionMs = oldPosition.positionMs,
+            mediaItemIndex = oldPosition.mediaItemIndex,
+        )
     }
 
     override fun onPlaybackStateChanged(playbackState: Int) {
         if (playbackState != Player.STATE_ENDED) return
-        // Queue ran out naturally — the still-current track played to its
-        // end. No transition fires for this case, so handle it here.
+        // Queue ran out — close out the still-current track using the
+        // player's own state (no transition fires for queue-end).
         val outgoing = current ?: return
-        flushListening(outgoing)
-        outgoing.startedAt = null
-        val uri = outgoing.uri
-        val now = nowMs()
-        scope.launch { repository.recordEvent(uri = uri, isPlay = true, now = now) }
+        finalizeOutgoing(
+            session = outgoing,
+            finalPositionMs = player.currentPosition.coerceAtLeast(0L),
+            mediaItemIndex = player.currentMediaItemIndex,
+        )
+        current = null
+        stopCheckpointLoop()
     }
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
+        if (current == null) return
+        if (isPlaying) startCheckpointLoop() else stopCheckpointLoop()
+    }
+
+    // Service tear-down hook — capture any progress the periodic loop hasn't.
+    fun flush() {
         val session = current ?: return
-        if (isPlaying) {
-            session.startedAt = nowMs()
-        } else {
-            flushListening(session)
-            session.startedAt = null
+        addProgressDelta(session, player.currentPosition.coerceAtLeast(0L))
+        stopCheckpointLoop()
+    }
+
+    private fun finalizeOutgoing(
+        session: Session,
+        finalPositionMs: Long,
+        mediaItemIndex: Int,
+    ) {
+        addProgressDelta(session, finalPositionMs)
+        val durationMs = readDuration(mediaItemIndex)
+        val event = classifyTransition(session.maxReachedPositionMs, durationMs)
+        if (!isTrackingEnabled()) return
+        val uri = session.uri
+        when (event) {
+            TransitionEvent.PLAY -> {
+                val now = nowMs()
+                scope.launch { repository.recordPlay(uri = uri, now = now) }
+            }
+            TransitionEvent.SKIP -> {
+                scope.launch { repository.recordSkip(uri = uri) }
+            }
+            TransitionEvent.NONE -> Unit
         }
     }
 
-    fun flush() {
-        val session = current ?: return
-        flushListening(session)
-        session.startedAt = null
-    }
-
-    private fun flushListening(session: Session) {
-        val startedAt = session.startedAt ?: return
-        val delta = (nowMs() - startedAt).coerceAtLeast(0L)
+    // Advances the session's flushed position and high-water mark, and
+    // writes the position-progress delta to the repository when the toggle
+    // is on. Seeking backward (delta < 0) is a no-op for everything except
+    // the maxReached check, which can't go up from a backward seek anyway.
+    private fun addProgressDelta(session: Session, currentPositionMs: Long) {
+        if (currentPositionMs > session.maxReachedPositionMs) {
+            session.maxReachedPositionMs = currentPositionMs
+        }
+        val delta = currentPositionMs - session.lastFlushedPositionMs
         if (delta <= 0L) return
+        session.lastFlushedPositionMs = currentPositionMs
+        if (!isTrackingEnabled()) return
         val uri = session.uri
-        scope.launch { repository.addListeningMs(uri = uri, ms = delta) }
+        scope.launch { repository.addListenedMs(uri = uri, ms = delta) }
     }
 
-    private fun readDuration(mediaItemIndex: Int): Long? {
+    private fun startCheckpointLoop() {
+        if (checkpointJob?.isActive == true) return
+        checkpointJob = scope.launch {
+            while (isActive) {
+                delay(checkpointIntervalMs)
+                val session = current ?: continue
+                addProgressDelta(session, player.currentPosition.coerceAtLeast(0L))
+            }
+        }
+    }
+
+    private fun stopCheckpointLoop() {
+        checkpointJob?.cancel()
+        checkpointJob = null
+    }
+
+    private fun readDuration(mediaItemIndex: Int): Long {
         val timeline = player.currentTimeline
-        if (mediaItemIndex < 0 || mediaItemIndex >= timeline.windowCount) return null
+        if (mediaItemIndex < 0 || mediaItemIndex >= timeline.windowCount) return 0L
         return runCatching { timeline.getWindow(mediaItemIndex, window).durationMs }
-            .getOrNull()
-            ?.takeIf { it > 0 }
+            .getOrDefault(0L)
+            .takeIf { it > 0L } ?: 0L
+    }
+
+    companion object {
+        private const val CHECKPOINT_INTERVAL_MS: Long = 10_000L
     }
 }

--- a/app/src/main/java/com/dn0ne/player/PlayThreshold.kt
+++ b/app/src/main/java/com/dn0ne/player/PlayThreshold.kt
@@ -1,0 +1,24 @@
+package com.dn0ne.player
+
+// Pure classifier for a track transition. Kept here (not nested inside the
+// listener) so it can be unit-tested without a Player.
+//
+// Rules:
+//   - duration <= 0 → NONE (live stream / broken file: don't lie about
+//     play vs skip when we can't tell)
+//   - maxReachedPositionMs >= duration / 2 → PLAY
+//   - otherwise → SKIP
+//
+// `maxReachedPositionMs` is the high-water mark of the playhead seen
+// during the session, so seeking *backward* after crossing 50 % doesn't
+// undo the play.
+internal enum class TransitionEvent { PLAY, SKIP, NONE }
+
+internal fun classifyTransition(
+    maxReachedPositionMs: Long,
+    durationMs: Long,
+): TransitionEvent = when {
+    durationMs <= 0L -> TransitionEvent.NONE
+    maxReachedPositionMs >= durationMs / 2L -> TransitionEvent.PLAY
+    else -> TransitionEvent.SKIP
+}

--- a/app/src/main/java/com/dn0ne/player/PlaybackService.kt
+++ b/app/src/main/java/com/dn0ne/player/PlaybackService.kt
@@ -25,6 +25,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -216,13 +220,19 @@ class PlaybackService : MediaSessionService() {
     private var mediaSession: MediaSession? = null
     private val equalizerController = get<EqualizerController>()
     private val trackStatsRepository = get<TrackStatsRepository>()
-    private val statsScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val settings = get<Settings>()
+    // The tracker reads player.currentPosition from a periodic checkpoint;
+    // ExoPlayer requires single-threaded access from the player's thread,
+    // which is main. Room's suspend DAO calls dispatch their own work to
+    // the room executor, so a single Dispatchers.Main scope is enough for
+    // both checkpoints and DB writes.
+    private val statsScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var playCountTracker: PlayCountTracker? = null
 
     override fun onCreate() {
         super.onCreate()
 
-        val shouldHandleAudioFocus = get<Settings>().handleAudioFocus
+        val shouldHandleAudioFocus = settings.handleAudioFocus
         val audioAttributes = AudioAttributes.Builder()
             .setUsage(C.USAGE_MEDIA)
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
@@ -249,7 +259,17 @@ class PlaybackService : MediaSessionService() {
             player = player,
             repository = trackStatsRepository,
             scope = statsScope,
+            isTrackingEnabled = { settings.trackPlayStats.value },
         ).also { player.addListener(it) }
+
+        // Toggle-off semantics: stop tracking *and* drop existing rows.
+        // drop(1) skips the StateFlow's initial replay so we only act on
+        // an actual user toggle, not on every service start.
+        settings.trackPlayStats
+            .drop(1)
+            .filter { !it }
+            .onEach { trackStatsRepository.clearAll() }
+            .launchIn(statsScope)
 
         SleepTimer.addOnFinishCallback {
             if (SleepTimer.finishLastTrack.value && player.isPlaying) {

--- a/app/src/main/java/com/dn0ne/player/app/data/backup/BackupData.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/backup/BackupData.kt
@@ -18,9 +18,12 @@ data class BackupData(
     val appVersionName: String,
     val playlists: List<BackupPlaylist>,
     val lovedTracks: List<BackupTrackRef>,
+    // Defaulted so v1 backups still parse cleanly. Bumped to v2 when this
+    // field was added in v1.5.6.
+    val trackStats: List<BackupTrackStats> = emptyList(),
 ) {
     companion object {
-        const val SCHEMA_VERSION = 1
+        const val SCHEMA_VERSION = 2
     }
 }
 
@@ -36,8 +39,26 @@ data class BackupTrackRef(
     val data: String,
 )
 
+@Serializable
+data class BackupTrackStats(
+    val uri: String,
+    val data: String,
+    val playCount: Int,
+    val skipCount: Int,
+    // Nullable so a stats row with only skips (no play timestamps yet)
+    // round-trips faithfully. Older backups that lacked this field are
+    // covered by the schema-default at parse time.
+    val firstPlayedAt: Long? = null,
+    val lastPlayedAt: Long? = null,
+    val totalListeningMs: Long,
+)
+
 sealed interface ExportResult {
-    data class Ok(val playlists: Int, val lovedTracks: Int) : ExportResult
+    data class Ok(
+        val playlists: Int,
+        val lovedTracks: Int,
+        val trackStats: Int,
+    ) : ExportResult
     data class Failure(val cause: Throwable) : ExportResult
 }
 
@@ -47,6 +68,8 @@ sealed interface ImportResult {
         val playlistsSkipped: Int,
         val lovedTracksAdded: Int,
         val tracksUnresolved: Int,
+        val statsImported: Int,
+        val statsSkippedDueToToggle: Boolean,
     ) : ImportResult
     data class Failure(val cause: Throwable) : ImportResult
 }

--- a/app/src/main/java/com/dn0ne/player/app/data/backup/BackupManager.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/backup/BackupManager.kt
@@ -6,8 +6,11 @@ import android.util.Log
 import com.dn0ne.player.app.data.repository.LovedTracksRepository
 import com.dn0ne.player.app.data.repository.PlaylistRepository
 import com.dn0ne.player.app.data.repository.TrackRepository
+import com.dn0ne.player.app.data.repository.TrackStatsRepository
 import com.dn0ne.player.app.domain.track.Playlist
 import com.dn0ne.player.app.domain.track.Track
+import com.dn0ne.player.app.domain.track.TrackStats
+import com.dn0ne.player.core.data.Settings
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -15,14 +18,18 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 /**
- * Read/write the user-data backup file (playlists and loved tracks) over the
- * URIs the user picks via Storage Access Framework.
+ * Read/write the user-data backup file (playlists, loved tracks, listening
+ * stats) over the URIs the user picks via Storage Access Framework.
  *
  * Import policy is *merge*, never replace:
  *
  * - Loved set: union with existing entries.
  * - Playlists: add by name; if a playlist with the same name already exists,
  *   the imported one is skipped (the result tells the caller how many).
+ * - Track stats: merged per-URI with max for counters/timestamps and min for
+ *   firstPlayedAt — re-importing the same backup is a no-op, importing an
+ *   older backup never erases newer activity. Skipped entirely if the
+ *   listening-stats privacy toggle is currently off.
  *
  * That means a restore against an empty database brings everything back, and
  * a restore against an in-use database can't silently destroy work the user
@@ -32,7 +39,9 @@ class BackupManager(
     private val context: Context,
     private val playlistRepository: PlaylistRepository,
     private val lovedTracksRepository: LovedTracksRepository,
+    private val trackStatsRepository: TrackStatsRepository,
     private val trackRepository: TrackRepository,
+    private val settings: Settings,
     private val appVersionName: String,
 ) {
 
@@ -48,6 +57,24 @@ class BackupManager(
             val lovedUris = lovedTracksRepository.observeLovedUris().first()
             val tracks = trackRepository.getTracks()
             val byUri = tracks.associateBy { it.uri.toString() }
+
+            // Stats: read every row, drop ones whose track isn't in the
+            // library at export time (we can't write a usable data path).
+            val statsRows = trackStatsRepository
+                .observeTopByPlayCount(limit = Int.MAX_VALUE)
+                .first()
+            val backupStats = statsRows.mapNotNull { row ->
+                val track = byUri[row.uri] ?: return@mapNotNull null
+                BackupTrackStats(
+                    uri = row.uri,
+                    data = track.data,
+                    playCount = row.playCount,
+                    skipCount = row.skipCount,
+                    firstPlayedAt = row.firstPlayedAt,
+                    lastPlayedAt = row.lastPlayedAt,
+                    totalListeningMs = row.totalListeningMs,
+                )
+            }
 
             val backup = BackupData(
                 exportedAt = System.currentTimeMillis(),
@@ -72,6 +99,7 @@ class BackupManager(
                     )
                     BackupTrackRef(uri = uri, data = track.data)
                 },
+                trackStats = backupStats,
             )
 
             val bytes = json.encodeToString(backup).toByteArray(Charsets.UTF_8)
@@ -81,6 +109,7 @@ class BackupManager(
             ExportResult.Ok(
                 playlists = backup.playlists.size,
                 lovedTracks = backup.lovedTracks.size,
+                trackStats = backup.trackStats.size,
             )
         } catch (t: Throwable) {
             Log.w(LOG_TAG, "Backup export failed", t)
@@ -151,11 +180,38 @@ class BackupManager(
                 }
             }
 
+            // Track stats: only honoured if the user has stats recording on.
+            // Off means "stop tracking, both directions" — importing into a
+            // disabled feature would be confusing.
+            val statsEnabled = settings.trackPlayStats.value
+            var statsImported = 0
+            if (statsEnabled && backup.trackStats.isNotEmpty()) {
+                val resolvedStats = backup.trackStats.mapNotNull { row ->
+                    val track = byUri[row.uri] ?: byPath[row.data]
+                    if (track == null) {
+                        unresolved++
+                        return@mapNotNull null
+                    }
+                    TrackStats(
+                        uri = track.uri.toString(),
+                        playCount = row.playCount,
+                        skipCount = row.skipCount,
+                        firstPlayedAt = row.firstPlayedAt,
+                        lastPlayedAt = row.lastPlayedAt,
+                        totalListeningMs = row.totalListeningMs,
+                    )
+                }
+                trackStatsRepository.mergeFromBackup(resolvedStats)
+                statsImported = resolvedStats.size
+            }
+
             ImportResult.Ok(
                 playlistsAdded = playlistsAdded,
                 playlistsSkipped = playlistsSkipped,
                 lovedTracksAdded = lovedAdded,
                 tracksUnresolved = unresolved,
+                statsImported = statsImported,
+                statsSkippedDueToToggle = !statsEnabled && backup.trackStats.isNotEmpty(),
             )
         } catch (t: Throwable) {
             Log.w(LOG_TAG, "Backup import failed", t)

--- a/app/src/main/java/com/dn0ne/player/app/data/db/TrackStatsDao.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/TrackStatsDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface TrackStatsDao {
@@ -12,39 +13,68 @@ interface TrackStatsDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertIfMissing(entity: TrackStatsEntity)
 
+    @Query("SELECT * FROM track_stats WHERE uri = :uri")
+    suspend fun getByUri(uri: String): TrackStatsEntity?
+
+    @Query("SELECT * FROM track_stats ORDER BY play_count DESC, last_played_at DESC LIMIT :limit")
+    fun observeTopByPlayCount(limit: Int): Flow<List<TrackStatsEntity>>
+
+    @Query(
+        "SELECT * FROM track_stats " +
+            "WHERE last_played_at IS NOT NULL " +
+            "ORDER BY last_played_at DESC LIMIT :limit"
+    )
+    fun observeRecentlyPlayed(limit: Int): Flow<List<TrackStatsEntity>>
+
+    // Play event: bumps play_count, sets first_played_at if absent, advances
+    // last_played_at monotonically. Listening time is owned by addListenedMs.
     @Query(
         "UPDATE track_stats " +
-            "SET play_count = play_count + :playInc, " +
-            "skip_count = skip_count + :skipInc, " +
+            "SET play_count = play_count + 1, " +
             "first_played_at = COALESCE(first_played_at, :now), " +
             "last_played_at = MAX(COALESCE(last_played_at, 0), :now) " +
             "WHERE uri = :uri"
     )
-    suspend fun applyTally(uri: String, playInc: Int, skipInc: Int, now: Long)
+    suspend fun applyPlay(uri: String, now: Long)
+
+    @Transaction
+    suspend fun recordPlay(uri: String, now: Long) {
+        insertIfMissing(TrackStatsEntity(uri = uri))
+        applyPlay(uri = uri, now = now)
+    }
+
+    // Skip: only the count moves. A skip isn't a "play," so it shouldn't
+    // touch first_played_at or last_played_at — those are reserved for
+    // intentional listening per the design spec.
+    @Query("UPDATE track_stats SET skip_count = skip_count + 1 WHERE uri = :uri")
+    suspend fun applySkip(uri: String)
+
+    @Transaction
+    suspend fun recordSkip(uri: String) {
+        insertIfMissing(TrackStatsEntity(uri = uri))
+        applySkip(uri = uri)
+    }
 
     @Query(
         "UPDATE track_stats " +
             "SET total_listening_ms = total_listening_ms + :ms " +
             "WHERE uri = :uri"
     )
-    suspend fun applyListeningMs(uri: String, ms: Long)
+    suspend fun applyListenedMs(uri: String, ms: Long)
 
     @Transaction
-    suspend fun recordEvent(uri: String, isPlay: Boolean, now: Long) {
+    suspend fun addListenedMs(uri: String, ms: Long) {
+        if (ms <= 0L) return
         insertIfMissing(TrackStatsEntity(uri = uri))
-        applyTally(
-            uri = uri,
-            playInc = if (isPlay) 1 else 0,
-            skipInc = if (isPlay) 0 else 1,
-            now = now,
-        )
+        applyListenedMs(uri = uri, ms = ms)
     }
 
-    @Transaction
-    suspend fun addListeningMs(uri: String, ms: Long) {
-        insertIfMissing(TrackStatsEntity(uri = uri))
-        applyListeningMs(uri = uri, ms = ms)
-    }
+    // Used by backup-import after the merge math in TrackStatsMerge has
+    // already produced the target row state. INSERT-or-REPLACE is fine
+    // here because the caller is reconciling a complete row, not nudging
+    // a counter.
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertReplacing(entity: TrackStatsEntity)
 
     @Query("DELETE FROM track_stats")
     suspend fun clearAll()

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/RoomTrackStatsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/RoomTrackStatsRepository.kt
@@ -1,20 +1,63 @@
 package com.dn0ne.player.app.data.repository
 
 import com.dn0ne.player.app.data.db.TrackStatsDao
+import com.dn0ne.player.app.data.db.TrackStatsEntity
+import com.dn0ne.player.app.domain.track.TrackStats
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class RoomTrackStatsRepository(
     private val dao: TrackStatsDao,
 ) : TrackStatsRepository {
 
-    override suspend fun recordEvent(uri: String, isPlay: Boolean, now: Long) {
-        dao.recordEvent(uri = uri, isPlay = isPlay, now = now)
+    override fun observeTopByPlayCount(limit: Int): Flow<List<TrackStats>> =
+        dao.observeTopByPlayCount(limit).map { it.map(TrackStatsEntity::toDomain) }
+
+    override fun observeRecentlyPlayed(limit: Int): Flow<List<TrackStats>> =
+        dao.observeRecentlyPlayed(limit).map { it.map(TrackStatsEntity::toDomain) }
+
+    override suspend fun statsFor(uri: String): TrackStats? =
+        dao.getByUri(uri)?.toDomain()
+
+    override suspend fun recordPlay(uri: String, now: Long) {
+        dao.recordPlay(uri = uri, now = now)
     }
 
-    override suspend fun addListeningMs(uri: String, ms: Long) {
-        dao.addListeningMs(uri = uri, ms = ms)
+    override suspend fun recordSkip(uri: String) {
+        dao.recordSkip(uri = uri)
+    }
+
+    override suspend fun addListenedMs(uri: String, ms: Long) {
+        dao.addListenedMs(uri = uri, ms = ms)
+    }
+
+    override suspend fun mergeFromBackup(rows: List<TrackStats>) {
+        for (incoming in rows) {
+            val local = dao.getByUri(incoming.uri)?.toDomain()
+            val merged = mergeStats(local = local, incoming = incoming)
+            dao.upsertReplacing(merged.toEntity())
+        }
     }
 
     override suspend fun clearAll() {
         dao.clearAll()
     }
 }
+
+private fun TrackStatsEntity.toDomain() = TrackStats(
+    uri = uri,
+    playCount = playCount,
+    skipCount = skipCount,
+    firstPlayedAt = firstPlayedAt,
+    lastPlayedAt = lastPlayedAt,
+    totalListeningMs = totalListeningMs,
+)
+
+private fun TrackStats.toEntity() = TrackStatsEntity(
+    uri = uri,
+    playCount = playCount,
+    skipCount = skipCount,
+    firstPlayedAt = firstPlayedAt,
+    lastPlayedAt = lastPlayedAt,
+    totalListeningMs = totalListeningMs,
+)

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/TrackStatsMerge.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/TrackStatsMerge.kt
@@ -1,0 +1,36 @@
+package com.dn0ne.player.app.data.repository
+
+import com.dn0ne.player.app.domain.track.TrackStats
+
+// Pure merge function for backup imports. Kept out of the repository so it
+// can be unit-tested without Room.
+//
+// Rules:
+//   - playCount, skipCount, totalListeningMs, lastPlayedAt → max(local, incoming)
+//   - firstPlayedAt → min(local, incoming) — earliest known first-play wins
+// Re-importing the same backup is a no-op. Importing an older backup never
+// erases newer activity.
+internal fun mergeStats(local: TrackStats?, incoming: TrackStats): TrackStats {
+    if (local == null) return incoming
+    return TrackStats(
+        uri = incoming.uri,
+        playCount = maxOf(local.playCount, incoming.playCount),
+        skipCount = maxOf(local.skipCount, incoming.skipCount),
+        firstPlayedAt = minNonNull(local.firstPlayedAt, incoming.firstPlayedAt),
+        lastPlayedAt = maxNonNull(local.lastPlayedAt, incoming.lastPlayedAt),
+        totalListeningMs = maxOf(local.totalListeningMs, incoming.totalListeningMs),
+    )
+}
+
+// Treat null as "unknown" — defer to whichever side has a value.
+private fun minNonNull(a: Long?, b: Long?): Long? = when {
+    a == null -> b
+    b == null -> a
+    else -> minOf(a, b)
+}
+
+private fun maxNonNull(a: Long?, b: Long?): Long? = when {
+    a == null -> b
+    b == null -> a
+    else -> maxOf(a, b)
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/TrackStatsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/TrackStatsRepository.kt
@@ -1,7 +1,15 @@
 package com.dn0ne.player.app.data.repository
 
+import com.dn0ne.player.app.domain.track.TrackStats
+import kotlinx.coroutines.flow.Flow
+
 interface TrackStatsRepository {
-    suspend fun recordEvent(uri: String, isPlay: Boolean, now: Long)
-    suspend fun addListeningMs(uri: String, ms: Long)
+    fun observeTopByPlayCount(limit: Int): Flow<List<TrackStats>>
+    fun observeRecentlyPlayed(limit: Int): Flow<List<TrackStats>>
+    suspend fun statsFor(uri: String): TrackStats?
+    suspend fun recordPlay(uri: String, now: Long)
+    suspend fun recordSkip(uri: String)
+    suspend fun addListenedMs(uri: String, ms: Long)
+    suspend fun mergeFromBackup(rows: List<TrackStats>)
     suspend fun clearAll()
 }

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -224,7 +224,9 @@ val playerModule = module {
             context = ctx,
             playlistRepository = get(),
             lovedTracksRepository = get(),
+            trackStatsRepository = get(),
             trackRepository = get(),
+            settings = get(),
             appVersionName = versionName,
         )
     }

--- a/app/src/main/java/com/dn0ne/player/app/domain/track/TrackStats.kt
+++ b/app/src/main/java/com/dn0ne/player/app/domain/track/TrackStats.kt
@@ -1,0 +1,13 @@
+package com.dn0ne.player.app.domain.track
+
+// Plain domain model the repository hands back. Mirrors the columns of the
+// Room entity but lives outside the data layer so the rest of the app
+// doesn't import androidx.room types.
+data class TrackStats(
+    val uri: String,
+    val playCount: Int,
+    val skipCount: Int,
+    val firstPlayedAt: Long?,
+    val lastPlayedAt: Long?,
+    val totalListeningMs: Long,
+)

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/BackupSettings.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/BackupSettings.kt
@@ -67,6 +67,7 @@ fun BackupSettings(
                     R.string.backup_export_success,
                     result.playlists,
                     result.lovedTracks,
+                    result.trackStats,
                 )
                 is ExportResult.Failure -> context.resources.getString(
                     R.string.backup_export_failure,
@@ -94,13 +95,26 @@ fun BackupSettings(
                     pendingImportUri = null
                     onImport(uri) { result ->
                         val msg = when (result) {
-                            is ImportResult.Ok -> context.resources.getString(
-                                R.string.backup_import_success,
-                                result.playlistsAdded,
-                                result.playlistsSkipped,
-                                result.lovedTracksAdded,
-                                result.tracksUnresolved,
-                            )
+                            is ImportResult.Ok -> {
+                                val base = context.resources.getString(
+                                    R.string.backup_import_success,
+                                    result.playlistsAdded,
+                                    result.playlistsSkipped,
+                                    result.lovedTracksAdded,
+                                    result.tracksUnresolved,
+                                )
+                                val statsLine = when {
+                                    result.statsSkippedDueToToggle -> context.resources.getString(
+                                        R.string.backup_import_stats_skipped,
+                                    )
+                                    result.statsImported > 0 -> context.resources.getString(
+                                        R.string.backup_import_stats_added,
+                                        result.statsImported,
+                                    )
+                                    else -> ""
+                                }
+                                if (statsLine.isEmpty()) base else "$base $statsLine"
+                            }
                             is ImportResult.Failure -> context.resources.getString(
                                 R.string.backup_import_failure,
                                 result.cause.localizedMessage ?: result.cause::class.simpleName.orEmpty(),

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/PrivacySettings.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/PrivacySettings.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.rounded.ArrowBackIosNew
 import androidx.compose.material.icons.rounded.Cloud
 import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.Insights
 import androidx.compose.material.icons.rounded.Public
 import androidx.compose.material.icons.rounded.Shield
 import androidx.compose.material3.Icon
@@ -20,6 +21,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -92,6 +94,16 @@ fun PrivacySettings(
                 settings.networkLookupsEnabled = it
                 networkLookupsEnabled = it
             },
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        val trackPlayStats by settings.trackPlayStats.collectAsState()
+        SettingSwitch(
+            title = context.resources.getString(R.string.track_play_stats),
+            supportingText = context.resources.getString(R.string.track_play_stats_explain),
+            icon = Icons.Rounded.Insights,
+            isChecked = trackPlayStats,
+            onCheckedChange = settings::updateTrackPlayStats,
             modifier = Modifier.fillMaxWidth(),
         )
 

--- a/app/src/main/java/com/dn0ne/player/core/data/Settings.kt
+++ b/app/src/main/java/com/dn0ne/player/core/data/Settings.kt
@@ -34,6 +34,7 @@ class Settings(context: Context) {
     private val useDarkPaletteOnLyricsSheetKey = "dark-palette-on-lyrics-sheet"
     private val useNetEaseLyricsFallbackKey = "use-netease-lyrics-fallback"
     private val networkLookupsEnabledKey = "network-lookups-enabled"
+    private val trackPlayStatsKey = "track-play-stats"
 
     private val areRisksOfMetadataEditingAcceptedKey = "metadata-editing-dialog"
 
@@ -241,6 +242,22 @@ class Settings(context: Context) {
                 apply()
             }
         }
+
+    // Privacy toggle for the listening-stats feature. Default true so the
+    // backing track_stats table fills up by default; flipping off both
+    // halts new writes (the listener checks this on every event) and
+    // clears the existing rows (PlaybackService observes the flow).
+    private val _trackPlayStats = MutableStateFlow(
+        sharedPreferences.getBoolean(trackPlayStatsKey, true)
+    )
+    val trackPlayStats = _trackPlayStats.asStateFlow()
+    fun updateTrackPlayStats(value: Boolean) {
+        _trackPlayStats.update { value }
+        with(sharedPreferences.edit()) {
+            putBoolean(trackPlayStatsKey, value)
+            apply()
+        }
+    }
 
     var areRisksOfMetadataEditingAccepted: Boolean
         get() = sharedPreferences.getBoolean(areRisksOfMetadataEditingAcceptedKey, false)

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -71,7 +71,7 @@
     <string name="backup_import_confirm_title">Восстановить из этого файла?</string>
     <string name="backup_import_confirm_body">Lotus прочитает выбранный файл и добавит новые записи. Ничего из имеющегося на устройстве не удаляется.</string>
     <string name="backup_import_confirm_yes">Восстановить</string>
-    <string name="backup_export_success">Сохранено: %1$d плейлистов и %2$d любимых треков.</string>
+    <string name="backup_export_success">Сохранено: %1$d плейлистов, %2$d любимых треков и %3$d записей статистики.</string>
     <string name="backup_export_failure">Не удалось сохранить копию: %1$s</string>
     <string name="backup_import_success">Добавлено %1$d плейлистов, пропущено по совпадению имён %2$d, любимых добавлено %3$d. %4$d записей не нашлись среди локальных файлов.</string>
     <string name="backup_import_failure">Не удалось прочитать копию: %1$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -71,7 +71,7 @@
     <string name="backup_import_confirm_title">Відновити з цього файлу?</string>
     <string name="backup_import_confirm_body">Lotus прочитає обраний файл і додасть нові записи. Ніщо з наявного на пристрої не видаляється.</string>
     <string name="backup_import_confirm_yes">Відновити</string>
-    <string name="backup_export_success">Збережено: %1$d плейлістів і %2$d улюблених треків.</string>
+    <string name="backup_export_success">Збережено: %1$d плейлістів, %2$d улюблених треків і %3$d записів статистики.</string>
     <string name="backup_export_failure">Не вдалося зберегти копію: %1$s</string>
     <string name="backup_import_success">Додано %1$d плейлістів, пропущено за збігом імен %2$d, улюблених додано %3$d. %4$d записів не знайшлися серед локальних файлів.</string>
     <string name="backup_import_failure">Не вдалося прочитати копію: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,9 +83,11 @@
     <string name="backup_import_confirm_title">Restore from this file?</string>
     <string name="backup_import_confirm_body">Lotus will read the file you picked and add anything new to your library. Nothing already on this device is removed.</string>
     <string name="backup_import_confirm_yes">Restore</string>
-    <string name="backup_export_success">Saved %1$d playlists and %2$d loved tracks.</string>
+    <string name="backup_export_success">Saved %1$d playlists, %2$d loved tracks, and %3$d listening-stats entries.</string>
     <string name="backup_export_failure">Couldn\'t save backup: %1$s</string>
     <string name="backup_import_success">Added %1$d playlists, skipped %2$d already-named, added %3$d loved tracks. %4$d entries didn\'t match any local file.</string>
+    <string name="backup_import_stats_added">Merged %1$d listening-stats entries.</string>
+    <string name="backup_import_stats_skipped">Listening-stats not imported (recording is off).</string>
     <string name="backup_import_failure">Couldn\'t read backup: %1$s</string>
 
     <!-- Tabs' names -->
@@ -280,6 +282,8 @@
     <string name="privacy_supporting_text">What leaves your device, network controls</string>
     <string name="network_lookups">Allow network lookups</string>
     <string name="network_lookups_explain">Master switch for LRCLIB lyrics, NetEase lyrics, and MusicBrainz metadata. Turn off for a strict-offline mode — the rest of the app keeps working from your local library.</string>
+    <string name="track_play_stats">Record listening stats</string>
+    <string name="track_play_stats_explain">Counts how often you play and skip tracks, and how long you\'ve listened to each one. Stored only on this device. Turning this off clears the existing counts.</string>
 
     <!-- Privacy disclosure -->
     <string name="privacy_what_leaves">What leaves your device</string>

--- a/app/src/test/java/com/dn0ne/player/PlayThresholdTest.kt
+++ b/app/src/test/java/com/dn0ne/player/PlayThresholdTest.kt
@@ -1,0 +1,45 @@
+package com.dn0ne.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlayThresholdTest {
+
+    @Test
+    fun zero_duration_is_indeterminate_event_none() {
+        // Live streams and broken-metadata files report duration <= 0; we
+        // shouldn't lie about play vs skip when we can't tell.
+        assertEquals(TransitionEvent.NONE, classifyTransition(maxReachedPositionMs = 0, durationMs = 0))
+        assertEquals(TransitionEvent.NONE, classifyTransition(maxReachedPositionMs = 1_000, durationMs = 0))
+        assertEquals(TransitionEvent.NONE, classifyTransition(maxReachedPositionMs = 999_999, durationMs = -1))
+    }
+
+    @Test
+    fun position_below_half_is_skip() {
+        assertEquals(TransitionEvent.SKIP, classifyTransition(maxReachedPositionMs = 0, durationMs = 200_000))
+        assertEquals(TransitionEvent.SKIP, classifyTransition(maxReachedPositionMs = 99_999, durationMs = 200_000))
+    }
+
+    @Test
+    fun position_at_or_past_half_is_play() {
+        assertEquals(TransitionEvent.PLAY, classifyTransition(maxReachedPositionMs = 100_000, durationMs = 200_000))
+        assertEquals(TransitionEvent.PLAY, classifyTransition(maxReachedPositionMs = 200_000, durationMs = 200_000))
+        assertEquals(TransitionEvent.PLAY, classifyTransition(maxReachedPositionMs = 250_000, durationMs = 200_000))
+    }
+
+    @Test
+    fun threshold_uses_integer_floor_for_odd_durations() {
+        // duration=3 → threshold = duration/2 = 1 (integer floor). Position 1
+        // crosses the bar, position 0 doesn't.
+        assertEquals(TransitionEvent.PLAY, classifyTransition(maxReachedPositionMs = 1, durationMs = 3))
+        assertEquals(TransitionEvent.SKIP, classifyTransition(maxReachedPositionMs = 0, durationMs = 3))
+    }
+
+    @Test
+    fun very_short_track_one_ms_long() {
+        // duration=1 → threshold = 0. Even being at position 0 counts as a
+        // play, which is the right behaviour for a track that's effectively
+        // a click — there's no room to "skip" something that short.
+        assertEquals(TransitionEvent.PLAY, classifyTransition(maxReachedPositionMs = 0, durationMs = 1))
+    }
+}

--- a/app/src/test/java/com/dn0ne/player/app/data/repository/TrackStatsMergeTest.kt
+++ b/app/src/test/java/com/dn0ne/player/app/data/repository/TrackStatsMergeTest.kt
@@ -1,0 +1,116 @@
+package com.dn0ne.player.app.data.repository
+
+import com.dn0ne.player.app.domain.track.TrackStats
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class TrackStatsMergeTest {
+
+    private val uri = "content://media/external/audio/media/42"
+
+    private fun stats(
+        playCount: Int = 0,
+        skipCount: Int = 0,
+        firstPlayedAt: Long? = null,
+        lastPlayedAt: Long? = null,
+        totalListeningMs: Long = 0L,
+    ) = TrackStats(
+        uri = uri,
+        playCount = playCount,
+        skipCount = skipCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt,
+        totalListeningMs = totalListeningMs,
+    )
+
+    @Test
+    fun missing_local_returns_incoming_unchanged() {
+        val incoming = stats(playCount = 3, totalListeningMs = 60_000L)
+        val merged = mergeStats(local = null, incoming = incoming)
+        assertEquals(incoming, merged)
+    }
+
+    @Test
+    fun counters_take_max_per_field() {
+        val local = stats(playCount = 5, skipCount = 2, totalListeningMs = 90_000L)
+        val incoming = stats(playCount = 3, skipCount = 7, totalListeningMs = 60_000L)
+        val merged = mergeStats(local, incoming)
+        assertEquals(5, merged.playCount)
+        assertEquals(7, merged.skipCount)
+        assertEquals(90_000L, merged.totalListeningMs)
+    }
+
+    @Test
+    fun first_played_takes_minimum_last_played_takes_maximum() {
+        val local = stats(firstPlayedAt = 2_000L, lastPlayedAt = 9_000L)
+        val incoming = stats(firstPlayedAt = 1_000L, lastPlayedAt = 5_000L)
+        val merged = mergeStats(local, incoming)
+        assertEquals(1_000L, merged.firstPlayedAt)
+        assertEquals(9_000L, merged.lastPlayedAt)
+    }
+
+    @Test
+    fun null_timestamps_defer_to_whichever_side_has_a_value() {
+        val local = stats(firstPlayedAt = null, lastPlayedAt = null)
+        val incoming = stats(firstPlayedAt = 1_000L, lastPlayedAt = 5_000L)
+        val merged = mergeStats(local, incoming)
+        assertEquals(1_000L, merged.firstPlayedAt)
+        assertEquals(5_000L, merged.lastPlayedAt)
+
+        val flipped = mergeStats(local = incoming, incoming = local)
+        assertEquals(1_000L, flipped.firstPlayedAt)
+        assertEquals(5_000L, flipped.lastPlayedAt)
+    }
+
+    @Test
+    fun re_importing_same_backup_is_a_no_op() {
+        // The user runs export, then immediately re-imports the same file:
+        // the merged row should equal the local row that produced the export.
+        val local = stats(
+            playCount = 5,
+            skipCount = 2,
+            firstPlayedAt = 1_000L,
+            lastPlayedAt = 9_000L,
+            totalListeningMs = 90_000L,
+        )
+        val merged = mergeStats(local = local, incoming = local)
+        assertEquals(local, merged)
+    }
+
+    @Test
+    fun older_backup_never_erases_newer_local_activity() {
+        // User exported a backup last month, listened to a track 5 more
+        // times since, then restored. The merge must not roll their
+        // counters back to the older numbers.
+        val newerLocal = stats(
+            playCount = 10,
+            skipCount = 3,
+            firstPlayedAt = 1_000L,
+            lastPlayedAt = 50_000L,
+            totalListeningMs = 200_000L,
+        )
+        val olderBackup = stats(
+            playCount = 5,
+            skipCount = 1,
+            firstPlayedAt = 1_000L,
+            lastPlayedAt = 20_000L,
+            totalListeningMs = 100_000L,
+        )
+        val merged = mergeStats(local = newerLocal, incoming = olderBackup)
+        assertEquals(newerLocal, merged)
+    }
+
+    @Test
+    fun merge_picks_up_earliest_first_play_from_either_side() {
+        // Two devices that started tracking the same track at different
+        // times: the cross-imported view should reflect the earliest.
+        val deviceA = stats(playCount = 3, firstPlayedAt = 5_000L, lastPlayedAt = 7_000L)
+        val deviceB = stats(playCount = 4, firstPlayedAt = 2_000L, lastPlayedAt = 6_000L)
+        val merged = mergeStats(local = deviceA, incoming = deviceB)
+        assertNotNull(merged.firstPlayedAt)
+        assertEquals(2_000L, merged.firstPlayedAt)
+        assertEquals(7_000L, merged.lastPlayedAt)
+        assertEquals(4, merged.playCount)
+    }
+}


### PR DESCRIPTION
Catch-up PR for items the design spec at \`docs/superpowers/specs/2026-05-06-play-count-infra-design.md\` scoped to PR A but #42 missed. Bumps to v1.5.6.

## What changed

- **Threshold uses a high-water mark.** \`maxReachedPositionMs\` is tracked per-session, so seeking backward after crossing 50% no longer undoes the play. Previously read \`oldPosition.positionMs\` straight, which had this correctness bug.
- **10s periodic checkpoint** while \`isPlaying\` is true. The only path that survives a service kill mid-track — previously, force-killing dropped the entire partial interval.
- **Listening-time model is now position-progress** (\`currentPosition - lastFlushedPositionMs\`, clamped to \`>= 0\`) instead of wallclock. Replaying the same section no longer double-counts.
- **Privacy toggle** — Settings → Privacy gets a "Record listening stats" switch. Off both halts new writes (gate inside the listener) and clears existing rows (PlaybackService observes the StateFlow, calls \`clearAll()\` on transition to false).
- **Backup integration.** \`BackupData\` schema v1 → v2 with a defaulted \`trackStats\` field so v1 backups still parse. Export reads \`track_stats\` and resolves URIs to data paths (drops unresolvable rows). Import applies max for \`playCount\` / \`skipCount\` / \`totalListeningMs\` / \`lastPlayedAt\`, min for \`firstPlayedAt\` — re-importing the same backup is a no-op, an older backup never erases newer activity. If the toggle is currently off, stats import is skipped silently and reported in the result toast.
- **DAO surface matches spec**: \`recordPlay\` (counts + timestamps), \`recordSkip\` (count only — skips no longer move \`firstPlayedAt\` or \`lastPlayedAt\`), \`addListenedMs\`, \`observeTopByPlayCount\`, \`observeRecentlyPlayed\`, \`getByUri\`, \`mergeFromBackup\`, \`clearAll\`.
- **Pure-JVM tests** for the threshold classifier and the merge math. No Robolectric / Room test infra added — the threshold and merge logic are extracted as pure functions so they're testable without it.
- **1.5.5 → 1.5.6** with a CHANGELOG entry; README "Features" and "Privacy" sections both reflect the new toggle and recording. \`backup_export_success\` strings updated in en/ru/uk to include the third placeholder.

## Test plan
- [ ] CI build + unit tests pass
- [ ] Install on device, play a full track → \`track_stats\` row gains \`play_count=1\`, non-zero \`total_listening_ms\`, populated timestamps
- [ ] Skip before 50% → \`skip_count\` increments, \`play_count\` stays, no timestamp move
- [ ] Skip after 50% → \`play_count\` increments
- [ ] Cross 50%, seek back to 10%, transition → still counts as a play (high-water mark)
- [ ] Pause for 30s mid-track, resume, finish → \`total_listening_ms\` reflects only the played-portion progress, not the wallclock pause
- [ ] Settings → Privacy → toggle off → existing rows are gone (verify via DB inspector or by exporting a backup and seeing \`trackStats: []\`)
- [ ] Toggle off, then import a backup that has stats → toast says "Listening-stats not imported (recording is off)"; counts not added
- [ ] Toggle on, import same backup → counts merge in
- [ ] Re-import same backup → no double-up (idempotent)