### PR TITLE
feat(stats): listening-stats screen (v1.5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ newest first. For the full picture of how this fork diverges from upstream
 Each release page on GitHub is built from the matching section below, so
 the wording is deliberately aimed at the end user.
 
+## 1.5.7 — Listening stats screen
+
+The numbers Lotus has been quietly recording since 1.5.6 now have a
+home. Settings → **Listening stats** shows four sections plus a small
+summary card.
+
+The summary card across the top: total time you've spent listening to
+local music in this app, the running tally of plays vs skips, and how
+many distinct tracks have stats yet.
+
+**Most played** is the top ten tracks by play count. **Most listened
+to** is the top ten by time spent — different from "most played" if a
+single long track has only been heard once or two but for hours
+combined. **Recently played** is the last ten you crossed the halfway
+mark on, newest first. **Top artists** rolls all your tracks up by
+artist tag and sorts by total listening time, so the artists you keep
+coming back to surface even if no single track of theirs is in the
+top-ten.
+
+The screen reads from the same on-device database the recording
+writes to — no network, no analytics. If you've turned the privacy
+toggle off (Settings → Privacy → Record listening stats), the stats
+screen shows a stub linking back to the toggle instead of an empty
+list.
+
 ## 1.5.6 — Listening stats (groundwork)
 
 Lotus now records how often you play and skip each track, and how long

--- a/README.md
+++ b/README.md
@@ -99,13 +99,17 @@ in [CHANGELOG.md](CHANGELOG.md); summaries below are cumulative.
   lists at the top: **Recently added** (files modified within the last
   30 days) and **Random mix** (up to 100 tracks shuffled). They feel
   like any other playlist — tap to open, play from, or export to M3U.
-- **Listening stats (groundwork)** — Lotus now records play count, skip
-  count, and listening time per track in the on-device database. Counts
-  follow the natural intuition: a play is +1 once you cross the halfway
-  mark of the track; a skip is +1 if you move on before that. The stats
-  screen that visualises this is the next planned release; for now it's
-  silent infrastructure that survives backup/restore and respects the
-  privacy toggle below.
+- **Listening stats** — Settings → Listening stats shows your top
+  played, top listened-to, recently played, and top artists, plus a
+  summary card with total time and play / skip counts. Counts follow
+  the natural intuition: +1 play once you cross the halfway mark of
+  the track, +1 skip if you move on before that. Seeking back after
+  crossing the halfway mark doesn't undo the play. All local — the
+  same on-device database as your playlists. Backup/restore carries
+  the stats too, with monotonic merge rules so re-importing the same
+  backup is a no-op. The whole feature can be turned off via the
+  privacy toggle below — flipping off both stops new recording and
+  drops the existing rows.
 
 ### Privacy and security
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.dn0ne.lotus.community"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1_005_006
-        versionName = "1.5.6-community"
+        versionCode = 1_005_007
+        versionName = "1.5.7-community"
 
         if (splitApks) {
             splits {

--- a/app/src/main/java/com/dn0ne/player/app/data/db/TrackStatsDao.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/TrackStatsDao.kt
@@ -16,6 +16,12 @@ interface TrackStatsDao {
     @Query("SELECT * FROM track_stats WHERE uri = :uri")
     suspend fun getByUri(uri: String): TrackStatsEntity?
 
+    // Drives the stats screen — every section is derived in Kotlin from
+    // this single observation so we don't issue four parallel queries
+    // that all return overlapping subsets of the same table.
+    @Query("SELECT * FROM track_stats")
+    fun observeAll(): Flow<List<TrackStatsEntity>>
+
     @Query("SELECT * FROM track_stats ORDER BY play_count DESC, last_played_at DESC LIMIT :limit")
     fun observeTopByPlayCount(limit: Int): Flow<List<TrackStatsEntity>>
 

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/RoomTrackStatsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/RoomTrackStatsRepository.kt
@@ -10,6 +10,9 @@ class RoomTrackStatsRepository(
     private val dao: TrackStatsDao,
 ) : TrackStatsRepository {
 
+    override fun observeAll(): Flow<List<TrackStats>> =
+        dao.observeAll().map { it.map(TrackStatsEntity::toDomain) }
+
     override fun observeTopByPlayCount(limit: Int): Flow<List<TrackStats>> =
         dao.observeTopByPlayCount(limit).map { it.map(TrackStatsEntity::toDomain) }
 

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/TrackStatsRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/TrackStatsRepository.kt
@@ -4,6 +4,7 @@ import com.dn0ne.player.app.domain.track.TrackStats
 import kotlinx.coroutines.flow.Flow
 
 interface TrackStatsRepository {
+    fun observeAll(): Flow<List<TrackStats>>
     fun observeTopByPlayCount(limit: Int): Flow<List<TrackStats>>
     fun observeRecentlyPlayed(limit: Int): Flow<List<TrackStats>>
     suspend fun statsFor(uri: String): TrackStats?

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -253,6 +253,7 @@ val playerModule = module {
             lyricsReader = get(),
             playlistRepository = get(),
             lovedTracksRepository = get(),
+            trackStatsRepository = get(),
             backupManager = get(),
             unsupportedArtworkEditFormats = get<MetadataWriter>().unsupportedArtworkEditFormats,
             settings = get(),

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
@@ -23,6 +23,7 @@ import com.dn0ne.player.app.data.repository.LovedTracksRepository
 import com.dn0ne.player.app.data.repository.LyricsRepository
 import com.dn0ne.player.app.data.repository.PlaylistRepository
 import com.dn0ne.player.app.data.repository.TrackRepository
+import com.dn0ne.player.app.data.repository.TrackStatsRepository
 import com.dn0ne.player.app.domain.lyrics.Lyrics
 import com.dn0ne.player.app.domain.lyrics.LyricsFetcher
 import com.dn0ne.player.app.domain.playlist.PlaylistEditor
@@ -71,6 +72,7 @@ class PlayerViewModel(
     private val lyricsReader: LyricsReader,
     private val playlistRepository: PlaylistRepository,
     private val lovedTracksRepository: LovedTracksRepository,
+    private val trackStatsRepository: TrackStatsRepository,
     private val backupManager: BackupManager,
     private val unsupportedArtworkEditFormats: List<String>,
     val settings: Settings,
@@ -96,7 +98,9 @@ class PlayerViewModel(
         SettingsSheetState(
             settings = settings,
             musicScanner = musicScanner,
-            equalizerController = equalizerController
+            equalizerController = equalizerController,
+            trackStatsRepository = trackStatsRepository,
+            trackRepository = trackRepository,
         )
     )
     val settingsSheetState = _settingsSheetState.stateIn(

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/LibraryStatsScreen.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/LibraryStatsScreen.kt
@@ -1,0 +1,496 @@
+package com.dn0ne.player.app.presentation.components.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBackIosNew
+import androidx.compose.material.icons.rounded.History
+import androidx.compose.material.icons.rounded.Insights
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Schedule
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ShapeDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import com.dn0ne.player.R
+import com.dn0ne.player.app.data.repository.TrackRepository
+import com.dn0ne.player.app.data.repository.TrackStatsRepository
+import com.dn0ne.player.app.domain.track.Track
+import com.dn0ne.player.app.domain.track.TrackStats
+import com.dn0ne.player.app.presentation.components.CoverArt
+import com.dn0ne.player.app.presentation.components.NoteCard
+import com.dn0ne.player.app.presentation.components.topbar.ColumnWithCollapsibleTopBar
+import com.dn0ne.player.core.data.Settings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val TOP_LIMIT = 10
+
+private data class TrackWithStats(val track: Track, val stats: TrackStats)
+private data class ArtistStats(
+    val artist: String,
+    val totalListeningMs: Long,
+    val playCount: Int,
+)
+
+private data class StatsViewState(
+    val totalListeningMs: Long,
+    val totalPlays: Int,
+    val totalSkips: Int,
+    val tracksWithStats: Int,
+    val mostPlayed: List<TrackWithStats>,
+    val mostListenedTo: List<TrackWithStats>,
+    val recentlyPlayed: List<TrackWithStats>,
+    val topArtists: List<ArtistStats>,
+) {
+    val isEmpty: Boolean get() = tracksWithStats == 0
+}
+
+@Composable
+fun LibraryStatsScreen(
+    settings: Settings,
+    statsRepository: TrackStatsRepository,
+    trackRepository: TrackRepository,
+    onBackClick: () -> Unit,
+    onOpenPrivacyClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var collapseFraction by remember { mutableFloatStateOf(0f) }
+
+    ColumnWithCollapsibleTopBar(
+        topBarContent = {
+            IconButton(
+                onClick = onBackClick,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.ArrowBackIosNew,
+                    contentDescription = context.resources.getString(R.string.back),
+                )
+            }
+
+            Text(
+                text = context.resources.getString(R.string.stats_title),
+                fontSize = lerp(
+                    MaterialTheme.typography.titleLarge.fontSize,
+                    MaterialTheme.typography.displaySmall.fontSize,
+                    collapseFraction,
+                ),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(horizontal = 16.dp),
+            )
+        },
+        collapseFraction = { collapseFraction = it },
+        contentPadding = PaddingValues(horizontal = 28.dp),
+        contentHorizontalAlignment = Alignment.CenterHorizontally,
+        contentVerticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .safeDrawingPadding(),
+    ) {
+        val isTrackingEnabled by settings.trackPlayStats.collectAsState()
+
+        if (!isTrackingEnabled) {
+            DisabledStub(onOpenPrivacyClick = onOpenPrivacyClick)
+            return@ColumnWithCollapsibleTopBar
+        }
+
+        val allStats by statsRepository.observeAll()
+            .collectAsState(initial = emptyList())
+
+        // Tracks come from MediaStore via a synchronous IO call, so wrap
+        // it in produceState. Re-loaded if the user comes back to this
+        // screen after a library scan.
+        val tracksByUri by produceState<Map<String, Track>>(
+            initialValue = emptyMap(),
+            key1 = allStats.size,
+        ) {
+            value = withContext(Dispatchers.IO) {
+                trackRepository.getTracks().associateBy { it.uri.toString() }
+            }
+        }
+
+        val viewState = remember(allStats, tracksByUri) {
+            buildViewState(allStats, tracksByUri)
+        }
+
+        if (viewState.isEmpty) {
+            EmptyStub()
+            return@ColumnWithCollapsibleTopBar
+        }
+
+        SummaryCard(viewState)
+
+        if (viewState.mostPlayed.isNotEmpty()) {
+            StatsSection(
+                title = context.resources.getString(R.string.stats_section_most_played),
+                content = {
+                    viewState.mostPlayed.forEach { item ->
+                        StatsTrackRow(
+                            track = item.track,
+                            metric = pluralPlays(context, item.stats.playCount),
+                        )
+                    }
+                },
+            )
+        }
+
+        if (viewState.mostListenedTo.isNotEmpty()) {
+            StatsSection(
+                title = context.resources.getString(R.string.stats_section_most_listened),
+                content = {
+                    viewState.mostListenedTo.forEach { item ->
+                        StatsTrackRow(
+                            track = item.track,
+                            metric = formatDuration(item.stats.totalListeningMs),
+                        )
+                    }
+                },
+            )
+        }
+
+        if (viewState.recentlyPlayed.isNotEmpty()) {
+            StatsSection(
+                title = context.resources.getString(R.string.stats_section_recently_played),
+                content = {
+                    viewState.recentlyPlayed.forEach { item ->
+                        StatsTrackRow(
+                            track = item.track,
+                            metric = pluralPlays(context, item.stats.playCount),
+                        )
+                    }
+                },
+            )
+        }
+
+        if (viewState.topArtists.isNotEmpty()) {
+            StatsSection(
+                title = context.resources.getString(R.string.stats_section_top_artists),
+                content = {
+                    viewState.topArtists.forEach { item ->
+                        StatsArtistRow(
+                            artist = item.artist,
+                            metric = formatDuration(item.totalListeningMs),
+                        )
+                    }
+                },
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+}
+
+private fun buildViewState(
+    stats: List<TrackStats>,
+    tracksByUri: Map<String, Track>,
+): StatsViewState {
+    if (stats.isEmpty()) {
+        return StatsViewState(
+            totalListeningMs = 0,
+            totalPlays = 0,
+            totalSkips = 0,
+            tracksWithStats = 0,
+            mostPlayed = emptyList(),
+            mostListenedTo = emptyList(),
+            recentlyPlayed = emptyList(),
+            topArtists = emptyList(),
+        )
+    }
+
+    // Drop rows whose track is no longer in the library — we have no
+    // sensible way to render them. The total count still reflects only
+    // resolved entries so the summary card matches what the user sees in
+    // the lists below.
+    val resolved = stats.mapNotNull { row ->
+        val track = tracksByUri[row.uri] ?: return@mapNotNull null
+        TrackWithStats(track = track, stats = row)
+    }
+
+    val totalListeningMs = resolved.sumOf { it.stats.totalListeningMs }
+    val totalPlays = resolved.sumOf { it.stats.playCount }
+    val totalSkips = resolved.sumOf { it.stats.skipCount }
+
+    val mostPlayed = resolved
+        .filter { it.stats.playCount > 0 }
+        .sortedWith(compareByDescending<TrackWithStats> { it.stats.playCount }.thenByDescending { it.stats.totalListeningMs })
+        .take(TOP_LIMIT)
+
+    val mostListenedTo = resolved
+        .filter { it.stats.totalListeningMs > 0 }
+        .sortedByDescending { it.stats.totalListeningMs }
+        .take(TOP_LIMIT)
+
+    val recentlyPlayed = resolved
+        .filter { it.stats.lastPlayedAt != null }
+        .sortedByDescending { it.stats.lastPlayedAt ?: 0L }
+        .take(TOP_LIMIT)
+
+    val topArtists = resolved
+        .filter { !it.track.artist.isNullOrBlank() && it.stats.totalListeningMs > 0 }
+        .groupBy { it.track.artist!! }
+        .map { (artist, items) ->
+            ArtistStats(
+                artist = artist,
+                totalListeningMs = items.sumOf { it.stats.totalListeningMs },
+                playCount = items.sumOf { it.stats.playCount },
+            )
+        }
+        .sortedByDescending { it.totalListeningMs }
+        .take(TOP_LIMIT)
+
+    return StatsViewState(
+        totalListeningMs = totalListeningMs,
+        totalPlays = totalPlays,
+        totalSkips = totalSkips,
+        tracksWithStats = resolved.size,
+        mostPlayed = mostPlayed,
+        mostListenedTo = mostListenedTo,
+        recentlyPlayed = recentlyPlayed,
+        topArtists = topArtists,
+    )
+}
+
+@Composable
+private fun SummaryCard(state: StatsViewState) {
+    val context = LocalContext.current
+    NoteCard(
+        label = context.resources.getString(R.string.stats_summary_title),
+        leadingIcon = Icons.Rounded.Insights,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        SummaryRow(
+            icon = Icons.Rounded.Schedule,
+            label = context.resources.getString(R.string.stats_summary_total_time),
+            value = formatDuration(state.totalListeningMs),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        SummaryRow(
+            icon = Icons.Rounded.PlayArrow,
+            label = context.resources.getString(R.string.stats_summary_plays_skips),
+            value = context.resources.getString(
+                R.string.stats_summary_plays_skips_value,
+                state.totalPlays,
+                state.totalSkips,
+            ),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        SummaryRow(
+            icon = Icons.Rounded.History,
+            label = context.resources.getString(R.string.stats_summary_tracks),
+            value = state.tracksWithStats.toString(),
+        )
+    }
+}
+
+@Composable
+private fun SummaryRow(icon: ImageVector, label: String, value: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = icon,
+            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun StatsSection(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp, top = 4.dp, bottom = 8.dp),
+        )
+        content()
+    }
+}
+
+@Composable
+private fun StatsTrackRow(track: Track, metric: String) {
+    val context = LocalContext.current
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+    ) {
+        CoverArt(
+            uri = track.coverArtUri,
+            modifier = Modifier
+                .size(44.dp)
+                .clip(ShapeDefaults.Small),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = track.title ?: context.resources.getString(R.string.unknown_title),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = track.artist ?: context.resources.getString(R.string.unknown_artist),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = metric,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun StatsArtistRow(artist: String, metric: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+    ) {
+        Text(
+            text = artist,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = metric,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun DisabledStub(onOpenPrivacyClick: () -> Unit) {
+    val context = LocalContext.current
+    NoteCard(
+        label = context.resources.getString(R.string.stats_disabled_title),
+        leadingIcon = Icons.Rounded.Insights,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(ShapeDefaults.Medium),
+    ) {
+        Text(
+            text = context.resources.getString(R.string.stats_disabled_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(ShapeDefaults.Small)
+                .background(color = MaterialTheme.colorScheme.tertiaryContainer)
+                .clickable(onClick = onOpenPrivacyClick)
+                .padding(vertical = 12.dp, horizontal = 16.dp),
+        ) {
+            Text(
+                text = context.resources.getString(R.string.stats_disabled_action),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyStub() {
+    val context = LocalContext.current
+    NoteCard(
+        label = context.resources.getString(R.string.stats_empty_title),
+        leadingIcon = Icons.Rounded.Insights,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = context.resources.getString(R.string.stats_empty_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+private fun formatDuration(ms: Long): String {
+    if (ms <= 0L) return "0m"
+    val totalMinutes = ms / 60_000L
+    val hours = totalMinutes / 60L
+    val minutes = totalMinutes % 60L
+    return when {
+        hours > 0 && minutes > 0 -> "${hours}h ${minutes}m"
+        hours > 0 -> "${hours}h"
+        totalMinutes > 0 -> "${minutes}m"
+        else -> "<1m"
+    }
+}
+
+private fun pluralPlays(context: android.content.Context, count: Int): String =
+    context.resources.getQuantityString(R.plurals.stats_plays, count, count)

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingsSheet.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingsSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.rounded.ArrowBackIosNew
 import androidx.compose.material.icons.rounded.Backup
 import androidx.compose.material.icons.rounded.ColorLens
 import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Insights
 import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.MusicNote
@@ -218,6 +219,14 @@ fun SettingsSheet(
                                     onClick = {
                                         navController.navigate(SettingsRoutes.Backup)
                                     }
+                                ),
+                                SettingsItem(
+                                    title = context.resources.getString(R.string.stats_title),
+                                    supportingText = context.resources.getString(R.string.stats_supporting_text),
+                                    icon = Icons.Rounded.Insights,
+                                    onClick = {
+                                        navController.navigate(SettingsRoutes.Stats)
+                                    }
                                 )
                             )
                         }
@@ -337,6 +346,21 @@ fun SettingsSheet(
                         modifier = Modifier.fillMaxSize()
                     )
                 }
+
+                composable<SettingsRoutes.Stats> {
+                    LibraryStatsScreen(
+                        settings = state.settings,
+                        statsRepository = state.trackStatsRepository,
+                        trackRepository = state.trackRepository,
+                        onBackClick = {
+                            navController.navigateUp()
+                        },
+                        onOpenPrivacyClick = {
+                            navController.navigate(SettingsRoutes.Privacy)
+                        },
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
             }
         }
     }
@@ -373,4 +397,7 @@ sealed interface SettingsRoutes {
 
     @Serializable
     data object About : SettingsRoutes
+
+    @Serializable
+    data object Stats : SettingsRoutes
 }

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingsSheetState.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/settings/SettingsSheetState.kt
@@ -1,6 +1,8 @@
 package com.dn0ne.player.app.presentation.components.settings
 
 import com.dn0ne.player.EqualizerController
+import com.dn0ne.player.app.data.repository.TrackRepository
+import com.dn0ne.player.app.data.repository.TrackStatsRepository
 import com.dn0ne.player.core.data.MusicScanner
 import com.dn0ne.player.core.data.Settings
 
@@ -9,5 +11,7 @@ data class SettingsSheetState(
     val musicScanner: MusicScanner,
     val isShown: Boolean = false,
     val equalizerController: EqualizerController,
+    val trackStatsRepository: TrackStatsRepository,
+    val trackRepository: TrackRepository,
     val foldersWithAudio: Set<String> = emptySet()
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,4 +409,26 @@
     <string name="share_crash_log_explain">Attach this file when filing a bug. Crash logs stay on your device.</string>
     <string name="no_crash_log_available">No crash logs on this device</string>
     <string name="share_crash_log_subject">Lotus crash report</string>
+
+    <!-- Listening stats screen -->
+    <string name="stats_title">Listening stats</string>
+    <string name="stats_supporting_text">Most played, most listened to, recently played, top artists</string>
+    <string name="stats_summary_title">Overall</string>
+    <string name="stats_summary_total_time">Total time listened</string>
+    <string name="stats_summary_plays_skips">Plays / skips</string>
+    <string name="stats_summary_plays_skips_value">%1$d / %2$d</string>
+    <string name="stats_summary_tracks">Tracks with stats</string>
+    <string name="stats_section_most_played">Most played</string>
+    <string name="stats_section_most_listened">Most listened to</string>
+    <string name="stats_section_recently_played">Recently played</string>
+    <string name="stats_section_top_artists">Top artists</string>
+    <string name="stats_disabled_title">Listening stats are off</string>
+    <string name="stats_disabled_body">Recording is disabled in Settings → Privacy. Turn it back on to start counting plays and skips again.</string>
+    <string name="stats_disabled_action">Open Privacy settings</string>
+    <string name="stats_empty_title">Nothing to show yet</string>
+    <string name="stats_empty_body">Play a few tracks past their halfway mark and they\'ll appear here.</string>
+    <plurals name="stats_plays">
+        <item quantity="one">%1$d play</item>
+        <item quantity="other">%1$d plays</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
PR B for the library-statistics feature. PR A (#42 + #43) laid the recording infrastructure; this one consumes it.

## What's in it
**Settings → Listening stats** with four sections plus a summary card:

- **Summary card** — total listening time, plays vs skips, distinct tracks with stats.
- **Most played** — top 10 by play count.
- **Most listened to** — top 10 by \`total_listening_ms\` (different from "most played" for tracks where one or two long plays dominate the runtime).
- **Recently played** — top 10 by \`last_played_at\`, newest first.
- **Top artists** — artist tag aggregated across all tracks, sorted by total listening time. Picks up the artists you keep coming back to even when no single track is in the top-ten.

## States
- **Tracking off** → stub linking back to Settings → Privacy. No empty-list confusion.
- **On but no plays yet** → stub explaining how to populate stats.
- **Tracks no longer in library** (deleted, SD card unmounted) → silently filtered out so summary numbers match what's displayed.

## Implementation notes
- One new DAO query: \`observeAll()\`. All sections + totals derive in Kotlin from a single flow rather than four parallel queries hitting overlapping subsets.
- Track resolution uses \`TrackRepository.getTracks()\` (MediaStore) wrapped in \`produceState\` so cold-open is responsive.
- New nav route \`SettingsRoutes.Stats\` registered in \`SettingsSheet\`. \`SettingsSheetState\` carries the stats + track repos through to the destination — keeps the wiring symmetric with how Privacy/Backup get \`Settings\`.
- Read-only rows; tapping a track in the stats list does nothing (it's a settings sub-screen, not a player surface).

## Strings
English only — \`values-ru\` and \`values-uk\` fall back to English for the new strings until a community translation lands. New plurals resource for "%d play(s)".

## Version + docs
1.5.6 → 1.5.7. CHANGELOG entry written end-user-facing. README "Listening stats" bullet promoted out of "(groundwork)" framing now that the feature is visible.

## Test plan
- [ ] CI build + unit tests pass
- [ ] Open Settings → Listening stats with no plays → empty stub appears
- [ ] Play 3 different tracks past 50% → all three appear in Most Played and Most Listened with correct counts
- [ ] Skip a track at 30% → it appears in neither Most Played nor Most Listened
- [ ] Toggle off in Privacy → stats screen shows disabled stub with action button → tap it → routes to Privacy
- [ ] Toggle on, play tracks of two different artists → Top artists shows both with correct totals
- [ ] Delete a previously-played track from the library, reopen stats → that track is gone from the lists, summary numbers reflect the removal