### PR TITLE
Fix dominant color logic

### DIFF
--- a/app/schemas/com.dn0ne.player.app.data.db.LotusDatabase/5.json
+++ b/app/schemas/com.dn0ne.player.app.data.db.LotusDatabase/5.json
@@ -1,0 +1,188 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "8af5a151beceaf734280f0eec6497ef5",
+    "entities": [
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `json` TEXT NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "lyrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `json` TEXT NOT NULL, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        }
+      },
+      {
+        "tableName": "loved_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        }
+      },
+      {
+        "tableName": "track_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `play_count` INTEGER NOT NULL, `skip_count` INTEGER NOT NULL, `total_listening_ms` INTEGER NOT NULL, `first_played_at` INTEGER, `last_played_at` INTEGER, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipCount",
+            "columnName": "skip_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListeningMs",
+            "columnName": "total_listening_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        }
+      },
+      {
+        "tableName": "track_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_data` TEXT NOT NULL, `mb_album_id` TEXT, `mb_release_group_id` TEXT, `mb_album_artist_id` TEXT, PRIMARY KEY(`track_data`))",
+        "fields": [
+          {
+            "fieldPath": "trackData",
+            "columnName": "track_data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mbAlbumId",
+            "columnName": "mb_album_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mbReleaseGroupId",
+            "columnName": "mb_release_group_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mbAlbumArtistId",
+            "columnName": "mb_album_artist_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_data"
+          ]
+        }
+      },
+      {
+        "tableName": "cover_art_colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cover_art_uri` TEXT NOT NULL, `dominant_color` INTEGER NOT NULL, PRIMARY KEY(`cover_art_uri`))",
+        "fields": [
+          {
+            "fieldPath": "coverArtUri",
+            "columnName": "cover_art_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dominantColor",
+            "columnName": "dominant_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cover_art_uri"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8af5a151beceaf734280f0eec6497ef5')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/dn0ne/player/app/data/db/LotusDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/dn0ne/player/app/data/db/LotusDatabaseMigrationTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.dn0ne.player.app.di.MIGRATION_1_2
 import com.dn0ne.player.app.di.MIGRATION_2_3
+import com.dn0ne.player.app.di.MIGRATION_4_5
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -97,6 +98,28 @@ class LotusDatabaseMigrationTest {
         assertEquals(6, statsCursor.columnCount)
         statsCursor.close()
 
+        migrated.close()
+    }
+
+    @Test
+    fun migrate_4_to_5_creates_cover_art_colors_table() {
+        val db = helper.createDatabase(LotusDatabase.NAME, 4)
+        db.close()
+
+        val migrated = helper.runMigrationsAndValidate(
+            LotusDatabase.NAME,
+            5,
+            true,
+            MIGRATION_4_5,
+        )
+
+        val cursor = migrated.query(
+            "SELECT cover_art_uri, dominant_color FROM cover_art_colors"
+        )
+        assertEquals(2, cursor.columnCount)
+        assertEquals("cover_art_uri", cursor.getColumnName(0))
+        assertEquals("dominant_color", cursor.getColumnName(1))
+        cursor.close()
         migrated.close()
     }
 }

--- a/app/src/main/java/com/dn0ne/player/app/data/CoverArtColorExtractor.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/CoverArtColorExtractor.kt
@@ -1,0 +1,50 @@
+package com.dn0ne.player.app.data
+
+import android.content.ContentResolver
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import com.kmpalette.color
+import com.kmpalette.generatePalette
+import com.kmpalette.palette.graphics.Palette
+import com.materialkolor.ktx.toHct
+
+class CoverArtColorExtractor(
+    private val contentResolver: ContentResolver,
+) {
+    suspend fun extractDominantColor(coverArtUri: Uri): Int? {
+        return try {
+            val bitmap = contentResolver.openInputStream(coverArtUri)?.use { input ->
+                BitmapFactory.decodeStream(input)
+            } ?: return null
+
+            selectDominantColor(bitmap.asImageBitmap().generatePalette()).toArgb()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    companion object {
+        fun selectOnColor(color: Int): Color {
+            return if (Color(color).luminance() < 0.5f) Color.White else Color.Black
+        }
+
+        fun selectDominantColor(palette: Palette): Color {
+            val swatches = palette.swatches.sortedByDescending { it.population }
+            if (swatches.isEmpty()) return Color.Unspecified
+
+            val firstSwatch = swatches.first()
+            val firstSwatchColorHct = firstSwatch.color.toHct()
+            val firstSwatchPopulation = firstSwatch.population
+            val moreChromatic = swatches.firstOrNull {
+                it.color.toHct().chroma - firstSwatchColorHct.chroma >= 30 &&
+                    it.population.toFloat() / firstSwatchPopulation >= .1f
+            }
+
+            return moreChromatic?.color ?: firstSwatch.color
+        }
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/db/CoverArtColorDao.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/CoverArtColorDao.kt
@@ -1,0 +1,20 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+
+@Dao
+interface CoverArtColorDao {
+    @Query("SELECT * FROM cover_art_colors WHERE cover_art_uri = :coverArtUri")
+    suspend fun getColor(coverArtUri: String): CoverArtColorEntity?
+
+    @Query("SELECT * FROM cover_art_colors")
+    suspend fun getAllColors(): List<CoverArtColorEntity>
+
+    @Query("SELECT cover_art_uri FROM cover_art_colors")
+    suspend fun getCachedUris(): List<String>
+
+    @Upsert
+    suspend fun upsert(entity: CoverArtColorEntity)
+}

--- a/app/src/main/java/com/dn0ne/player/app/data/db/CoverArtColorEntity.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/CoverArtColorEntity.kt
@@ -1,0 +1,14 @@
+package com.dn0ne.player.app.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "cover_art_colors")
+data class CoverArtColorEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "cover_art_uri")
+    val coverArtUri: String,
+    @ColumnInfo(name = "dominant_color")
+    val dominantColor: Int,
+)

--- a/app/src/main/java/com/dn0ne/player/app/data/db/LotusDatabase.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/db/LotusDatabase.kt
@@ -10,8 +10,9 @@ import androidx.room.RoomDatabase
         LovedTrackEntity::class,
         TrackStatsEntity::class,
         TrackMetadataEntity::class,
+        CoverArtColorEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 abstract class LotusDatabase : RoomDatabase() {
@@ -20,6 +21,7 @@ abstract class LotusDatabase : RoomDatabase() {
     abstract fun lovedTrackDao(): LovedTrackDao
     abstract fun trackStatsDao(): TrackStatsDao
     abstract fun trackMetadataDao(): TrackMetadataDao
+    abstract fun coverArtColorDao(): CoverArtColorDao
 
     companion object {
         const val NAME = "lotus.db"

--- a/app/src/main/java/com/dn0ne/player/app/data/repository/CoverArtColorRepository.kt
+++ b/app/src/main/java/com/dn0ne/player/app/data/repository/CoverArtColorRepository.kt
@@ -1,0 +1,24 @@
+package com.dn0ne.player.app.data.repository
+
+import com.dn0ne.player.app.data.db.CoverArtColorDao
+import com.dn0ne.player.app.data.db.CoverArtColorEntity
+
+class CoverArtColorRepository(
+    private val dao: CoverArtColorDao,
+) {
+    suspend fun getDominantColor(coverArtUri: String): Int? {
+        return dao.getColor(coverArtUri)?.dominantColor
+    }
+
+    suspend fun getAllDominantColors(): Map<String, Int> {
+        return dao.getAllColors().associate { it.coverArtUri to it.dominantColor }
+    }
+
+    suspend fun getCachedUris(): Set<String> {
+        return dao.getCachedUris().toSet()
+    }
+
+    suspend fun cacheDominantColor(coverArtUri: String, color: Int) {
+        dao.upsert(CoverArtColorEntity(coverArtUri, color))
+    }
+}

--- a/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
+++ b/app/src/main/java/com/dn0ne/player/app/di/PlayerModule.kt
@@ -11,6 +11,7 @@ import com.dn0ne.player.app.data.MetadataWriter
 import com.dn0ne.player.app.data.MetadataWriterImpl
 import com.dn0ne.player.app.data.SavedPlayerState
 import com.dn0ne.player.app.data.backup.BackupManager
+import com.dn0ne.player.app.data.db.CoverArtColorDao
 import com.dn0ne.player.app.data.db.LotusDatabase
 import com.dn0ne.player.app.data.db.LovedTrackDao
 import com.dn0ne.player.app.data.db.LyricsDao
@@ -26,6 +27,7 @@ import com.dn0ne.player.app.data.remote.metadata.GatedMetadataProvider
 import com.dn0ne.player.app.data.remote.metadata.MetadataProvider
 import com.dn0ne.player.app.data.remote.metadata.MusicBrainzMetadataProvider
 import com.dn0ne.player.core.util.RateLimiter
+import com.dn0ne.player.app.data.repository.CoverArtColorRepository
 import com.dn0ne.player.app.data.repository.LovedTracksRepository
 import com.dn0ne.player.app.data.repository.LyricsRepository
 import com.dn0ne.player.app.data.repository.PlaylistRepository
@@ -110,6 +112,17 @@ internal val MIGRATION_3_4 = object : Migration(3, 4) {
                 "`mb_release_group_id` TEXT, " +
                 "`mb_album_artist_id` TEXT, " +
                 "PRIMARY KEY(`track_data`))"
+        )
+    }
+}
+
+internal val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `cover_art_colors` (" +
+                "`cover_art_uri` TEXT NOT NULL, " +
+                "`dominant_color` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`cover_art_uri`))"
         )
     }
 }
@@ -222,7 +235,7 @@ val playerModule = module {
             LotusDatabase::class.java,
             LotusDatabase.NAME,
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
             .build()
     }
     single<PlaylistDao> { get<LotusDatabase>().playlistDao() }
@@ -230,6 +243,7 @@ val playerModule = module {
     single<LovedTrackDao> { get<LotusDatabase>().lovedTrackDao() }
     single<TrackStatsDao> { get<LotusDatabase>().trackStatsDao() }
     single<TrackMetadataDao> { get<LotusDatabase>().trackMetadataDao() }
+    single<CoverArtColorDao> { get<LotusDatabase>().coverArtColorDao() }
 
     single {
         LyricsRepository(dao = get())
@@ -245,6 +259,10 @@ val playerModule = module {
 
     single {
         TrackStatsRepository(dao = get())
+    }
+
+    single {
+        CoverArtColorRepository(dao = get())
     }
 
     single<BackupManager> {
@@ -295,6 +313,7 @@ val playerModule = module {
             playlistRepository = get(),
             lovedTracksRepository = get(),
             trackStatsRepository = get(),
+            coverArtColorRepository = get(),
             backupManager = get(),
             unsupportedWriteFormats = get<MetadataWriter>().unsupportedWriteFormats,
             unsupportedCoverArtFormats = (get<MetadataWriter>() as MetadataWriterImpl).unsupportedCoverArtFormats,

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerScreen.kt
@@ -1,5 +1,6 @@
 package com.dn0ne.player.app.presentation
 
+import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -92,6 +93,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.dn0ne.player.R
+import com.dn0ne.player.app.data.CoverArtColorExtractor
 import com.dn0ne.player.app.domain.sort.PlaylistSort
 import com.dn0ne.player.app.domain.sort.SortOrder
 import com.dn0ne.player.app.domain.sort.TrackSort
@@ -102,6 +104,7 @@ import com.dn0ne.player.app.domain.track.Track
 import com.dn0ne.player.app.domain.track.filterPlaylists
 import com.dn0ne.player.app.domain.track.filterTracks
 import com.dn0ne.player.app.presentation.components.GlobalSearchSheet
+import com.dn0ne.player.app.presentation.components.LocalDominantColorCache
 import com.dn0ne.player.app.presentation.components.PlaylistSortButton
 import com.dn0ne.player.app.presentation.components.TrackSortButton
 import com.dn0ne.player.app.presentation.components.playback.PlayerSheet
@@ -124,6 +127,7 @@ import com.dn0ne.player.app.presentation.components.topbar.TopBarContent
 import com.dn0ne.player.app.presentation.components.trackList
 import com.dn0ne.player.app.presentation.components.trackinfo.SearchField
 import com.dn0ne.player.app.presentation.components.trackinfo.TrackInfoSheet
+import androidx.compose.ui.graphics.toArgb
 import com.kmpalette.color
 import com.kmpalette.rememberDominantColorState
 import com.materialkolor.DynamicMaterialTheme
@@ -145,37 +149,55 @@ fun PlayerScreen(
 ) {
     val useDynamicColor by viewModel.settings.useDynamicColor.collectAsState()
     val useAlbumArtColor by viewModel.settings.useAlbumArtColor.collectAsState()
+    val dominantColorCache by viewModel.dominantColorCache.collectAsState()
+    val playbackState by viewModel.playbackState.collectAsState()
+    val currentTrack by remember {
+        derivedStateOf { playbackState.currentTrack }
+    }
     val dominantColorState = rememberDominantColorState()
     var coverArtBitmap by remember {
         mutableStateOf<ImageBitmap?>(null)
     }
-    val colorToApply by remember(coverArtBitmap, useAlbumArtColor, useDynamicColor) {
+    var coverArtBitmapTrackUri by remember {
+        mutableStateOf<Uri?>(null)
+    }
+    val cachedColor = currentTrack?.let { dominantColorCache[it.coverArtUri.toString()] }
+    val bitmapIsFresh = currentTrack?.uri == coverArtBitmapTrackUri
+    val colorToApply by remember(cachedColor, coverArtBitmap, coverArtBitmapTrackUri, useAlbumArtColor, useDynamicColor) {
         derivedStateOf {
-            if (useAlbumArtColor && coverArtBitmap != null) {
+            if (useAlbumArtColor && cachedColor != null) {
+                Color(cachedColor)
+            } else if (useAlbumArtColor && coverArtBitmap != null && bitmapIsFresh) {
                 dominantColorState.result
                     ?.paletteOrNull
-                    ?.swatches
-                    ?.sortedByDescending { it.population }
-                    ?.let { swatches ->
-                        val firstSwatch = swatches.first()
-                        val firstSwatchColorHct = firstSwatch.color.toHct()
-                        val firstSwatchPopulation = firstSwatch.population
-                        val moreChromatic = swatches.fastFirstOrNull {
-                            it.color.toHct().chroma - firstSwatchColorHct.chroma >= 30 &&
-                                    it.population.toFloat() / firstSwatchPopulation >= .1f
-                        }
-                        moreChromatic?.color ?: firstSwatch.color
-                    } ?: dominantColorState.color
+                    ?.let { CoverArtColorExtractor.selectDominantColor(it) }
+                    ?: dominantColorState.color
             } else dominantColorState.color
         }
     }
 
-    LaunchedEffect(useAlbumArtColor, useDynamicColor) {
-        if (useAlbumArtColor) {
-            coverArtBitmap?.let {
-                dominantColorState.updateFrom(it)
+    LaunchedEffect(useAlbumArtColor, useDynamicColor, coverArtBitmap, coverArtBitmapTrackUri) {
+        val bitmap = coverArtBitmap
+        if (useAlbumArtColor && bitmap != null && coverArtBitmapTrackUri == currentTrack?.uri) {
+            dominantColorState.updateFrom(bitmap)
+            val computedColor = dominantColorState.result
+                ?.paletteOrNull
+                ?.let { CoverArtColorExtractor.selectDominantColor(it) }
+                ?: dominantColorState.color
+            currentTrack?.let { track ->
+                viewModel.cacheDominantColor(track.coverArtUri.toString(), computedColor.toArgb())
             }
-        } else dominantColorState.reset()
+        } else {
+            dominantColorState.reset()
+        }
+    }
+
+    LaunchedEffect(currentTrack) {
+        if (currentTrack == null) {
+            coverArtBitmap = null
+            coverArtBitmapTrackUri = null
+            dominantColorState.reset()
+        }
     }
 
     val appearance by viewModel.settings.appearance.collectAsState()
@@ -214,7 +236,8 @@ fun PlayerScreen(
         CompositionLocalProvider(
             LocalIndication provides ripple,
             LocalRippleConfiguration provides rippleConfiguration,
-            LocalContentColor provides MaterialTheme.colorScheme.onSurface
+            LocalContentColor provides MaterialTheme.colorScheme.onSurface,
+            LocalDominantColorCache provides dominantColorCache,
         ) {
 
             Box(
@@ -222,20 +245,6 @@ fun PlayerScreen(
                     .background(color = MaterialTheme.colorScheme.background)
             ) {
                 val context = LocalContext.current
-                val playbackState by viewModel.playbackState.collectAsState()
-                val currentTrack by remember {
-                    derivedStateOf {
-                        playbackState.currentTrack
-                    }
-                }
-
-                LaunchedEffect(currentTrack) {
-                    if (currentTrack == null) {
-                        coverArtBitmap = null
-                        dominantColorState.reset()
-                    }
-                }
-
                 val perTrackArtwork = viewModel.settings.perTrackArtwork
                 val trackSort by viewModel.trackSort.collectAsState()
                 val trackSortOrder by viewModel.trackSortOrder.collectAsState()
@@ -539,6 +548,9 @@ fun PlayerScreen(
                                 )
                             },
                             perTrackArtwork = perTrackArtwork,
+                            onDominantColorExtracted = { uri, color ->
+                                viewModel.cacheDominantColor(uri, color)
+                            },
                         )
                     }
 
@@ -867,6 +879,7 @@ fun PlayerScreen(
                                 },
                                 onCoverArtLoaded = {
                                     coverArtBitmap = it
+                                    coverArtBitmapTrackUri = currentTrack?.uri
                                 },
                                 onPlayNextClick = {
                                     viewModel.onEvent(PlayerScreenEvent.OnPlayNextClick(it))
@@ -1047,6 +1060,7 @@ private fun LazyGridScope.TabContent(
     onEnterSelectionMode: (Playlist) -> Unit,
     onToggleSelection: (Playlist) -> Unit,
     perTrackArtwork: Boolean = false,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
 ) {
     if (gridPlaylists) {
         if (!isInSelectionMode) {
@@ -1058,7 +1072,8 @@ private fun LazyGridScope.TabContent(
                 showSinglePreview = showSinglePreview,
                 perTrackArtwork = perTrackArtwork,
                 onCardClick = onPlaylistClick,
-                onLongClick = { onEnterSelectionMode(it) }
+                onLongClick = { onEnterSelectionMode(it) },
+                onDominantColorExtracted = onDominantColorExtracted,
             )
         } else {
             selectionCards(
@@ -1069,7 +1084,8 @@ private fun LazyGridScope.TabContent(
                 fallbackPlaylistTitle = fallbackPlaylistTitle,
                 showSinglePreview = showSinglePreview,
                 perTrackArtwork = perTrackArtwork,
-                onCardClick = { onToggleSelection(it) }
+                onCardClick = { onToggleSelection(it) },
+                onDominantColorExtracted = onDominantColorExtracted,
             )
         }
     } else {
@@ -1082,7 +1098,8 @@ private fun LazyGridScope.TabContent(
                 showSinglePreview = showSinglePreview,
                 perTrackArtwork = perTrackArtwork,
                 onRowClick = onPlaylistClick,
-                onLongClick = { onEnterSelectionMode(it) }
+                onLongClick = { onEnterSelectionMode(it) },
+                onDominantColorExtracted = onDominantColorExtracted,
             )
         } else {
             selectionRows(
@@ -1093,7 +1110,8 @@ private fun LazyGridScope.TabContent(
                 fallbackPlaylistTitle = fallbackPlaylistTitle,
                 showSinglePreview = showSinglePreview,
                 perTrackArtwork = perTrackArtwork,
-                onRowClick = { onToggleSelection(it) }
+                onRowClick = { onToggleSelection(it) },
+                onDominantColorExtracted = onDominantColorExtracted,
             )
         }
     }
@@ -1149,6 +1167,7 @@ fun MainPlayerScreen(
     gridPlaylists: Boolean,
     onGridPlaylistsClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
     perTrackArtwork: Boolean = false,
 ) {
     val context = LocalContext.current
@@ -1703,7 +1722,8 @@ fun MainPlayerScreen(
                         if (selectedPlaylists.isEmpty()) {
                             isInSelectionMode = false
                         }
-                    }
+                    },
+                    onDominantColorExtracted = onDominantColorExtracted,
                 )
             }
 
@@ -1729,7 +1749,8 @@ fun MainPlayerScreen(
                         if (selectedPlaylists.isEmpty()) {
                             isInSelectionMode = false
                         }
-                    }
+                    },
+                    onDominantColorExtracted = onDominantColorExtracted,
                 )
             }
 
@@ -1755,7 +1776,8 @@ fun MainPlayerScreen(
                         if (selectedPlaylists.isEmpty()) {
                             isInSelectionMode = false
                         }
-                    }
+                    },
+                    onDominantColorExtracted = onDominantColorExtracted,
                 )
             }
 
@@ -1781,7 +1803,8 @@ fun MainPlayerScreen(
                         if (selectedPlaylists.isEmpty()) {
                             isInSelectionMode = false
                         }
-                    }
+                    },
+                    onDominantColorExtracted = onDominantColorExtracted,
                 )
             }
         }

--- a/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/PlayerViewModel.kt
@@ -23,6 +23,7 @@ import com.dn0ne.player.app.data.backup.ExportResult
 import com.dn0ne.player.app.data.backup.ImportResult
 import com.dn0ne.player.app.data.remote.lyrics.LyricsProvider
 import com.dn0ne.player.app.data.remote.metadata.MetadataProvider
+import com.dn0ne.player.app.data.repository.CoverArtColorRepository
 import com.dn0ne.player.app.data.repository.LovedTracksRepository
 import com.dn0ne.player.app.data.repository.LyricsRepository
 import com.dn0ne.player.app.data.repository.PlaylistRepository
@@ -81,6 +82,7 @@ class PlayerViewModel(
     private val playlistRepository: PlaylistRepository,
     private val lovedTracksRepository: LovedTracksRepository,
     private val trackStatsRepository: TrackStatsRepository,
+    private val coverArtColorRepository: CoverArtColorRepository,
     private val backupManager: BackupManager,
     private val unsupportedWriteFormats: List<String>,
     private val unsupportedCoverArtFormats: List<String>,
@@ -237,6 +239,20 @@ class PlayerViewModel(
         }
     }
 
+    private val _dominantColorCache = MutableStateFlow<Map<String, Int>>(emptyMap())
+    val dominantColorCache = _dominantColorCache.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000L),
+        initialValue = emptyMap()
+    )
+
+    fun cacheDominantColor(coverArtUri: String, color: Int) {
+        viewModelScope.launch(Dispatchers.IO) {
+            coverArtColorRepository.cacheDominantColor(coverArtUri, color)
+            _dominantColorCache.update { it + (coverArtUri to color) }
+        }
+    }
+
     private val _trackList = MutableStateFlow(emptyList<Track>())
     val trackList = _trackList.stateIn(
         scope = viewModelScope,
@@ -369,6 +385,10 @@ class PlayerViewModel(
     private val _pendingTrackUris = Channel<Uri>()
 
     init {
+        viewModelScope.launch(Dispatchers.IO) {
+            _dominantColorCache.value = coverArtColorRepository.getAllDominantColors()
+        }
+
         viewModelScope.launch(Dispatchers.IO) {
             while (true) {
                 val tracks = trackRepository.getTracks()

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/DominantColorCache.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/DominantColorCache.kt
@@ -1,0 +1,5 @@
+package com.dn0ne.player.app.presentation.components
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalDominantColorCache = staticCompositionLocalOf<Map<String, Int>> { emptyMap() }

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/PlaylistCards.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/PlaylistCards.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -40,7 +41,9 @@ import com.dn0ne.player.app.domain.sort.PlaylistSort
 import com.dn0ne.player.app.domain.sort.SortOrder
 import com.dn0ne.player.app.domain.sort.sortedBy
 import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.data.CoverArtColorExtractor
 import com.dn0ne.player.app.presentation.components.CoverArt
+import com.dn0ne.player.app.presentation.components.LocalDominantColorCache
 import com.dn0ne.player.app.presentation.components.NothingYet
 import com.kmpalette.rememberDominantColorState
 import kotlinx.coroutines.launch
@@ -55,6 +58,7 @@ fun LazyGridScope.playlistCards(
     onLongClick: (Playlist) -> Unit,
     showSinglePreview: Boolean = false,
     perTrackArtwork: Boolean = false,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
 ) {
     if (playlists.isEmpty()) {
         item(
@@ -81,6 +85,7 @@ fun LazyGridScope.playlistCards(
                 .take(if (showSinglePreview) 1 else 4)
                 .map { it.uri },
             perTrackArtwork = perTrackArtwork,
+            onDominantColorExtracted = onDominantColorExtracted,
             modifier = Modifier
                 .clip(ShapeDefaults.Large)
                 .combinedClickable(
@@ -102,6 +107,7 @@ fun PlaylistCard(
     coverArtPreviewUris: List<Uri>,
     trackUris: List<Uri> = emptyList(),
     perTrackArtwork: Boolean = false,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -112,6 +118,9 @@ fun PlaylistCard(
             if (coverArtPreviewUris.size <= 1) {
                 val dominantColorState = rememberDominantColorState()
                 val coroutineScope = rememberCoroutineScope()
+                val dominantColorCache = LocalDominantColorCache.current
+                val cachedColor = coverArtPreviewUris.firstOrNull()?.toString()
+                    ?.let { dominantColorCache[it] }
                 CoverArt(
                     uri = coverArtPreviewUris.firstOrNull() ?: Uri.EMPTY,
                     trackUri = trackUris.firstOrNull(),
@@ -120,6 +129,13 @@ fun PlaylistCard(
                         bitmap?.let {
                             coroutineScope.launch {
                                 dominantColorState.updateFrom(it)
+                                val uri = coverArtPreviewUris.firstOrNull()?.toString()
+                                if (uri != null) {
+                                    val color = dominantColorState.result?.paletteOrNull
+                                        ?.let { CoverArtColorExtractor.selectDominantColor(it) }
+                                        ?: dominantColorState.color
+                                    onDominantColorExtracted(uri, color.toArgb())
+                                }
                             }
                         }
                     },
@@ -128,10 +144,15 @@ fun PlaylistCard(
                         .clip(ShapeDefaults.Large)
                 )
 
+                val containerColor = cachedColor?.let { Color(it) }
+                    ?: dominantColorState.color
+                val contentColor = cachedColor?.let { CoverArtColorExtractor.selectOnColor(it) }
+                    ?: dominantColorState.onColor
+
                 TrackCountBubble(
                     trackCount = trackCount,
-                    contentColor = dominantColorState.onColor,
-                    containerColor = dominantColorState.color,
+                    contentColor = contentColor,
+                    containerColor = containerColor,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .offset(y = (-4).dp)

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/PlaylistRows.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/playlist/PlaylistRows.kt
@@ -27,8 +27,12 @@ import com.dn0ne.player.app.domain.sort.PlaylistSort
 import com.dn0ne.player.app.domain.sort.SortOrder
 import com.dn0ne.player.app.domain.sort.sortedBy
 import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.data.CoverArtColorExtractor
 import com.dn0ne.player.app.presentation.components.CoverArt
+import com.dn0ne.player.app.presentation.components.LocalDominantColorCache
 import com.dn0ne.player.app.presentation.components.NothingYet
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import com.kmpalette.rememberDominantColorState
 import kotlinx.coroutines.launch
 
@@ -42,6 +46,7 @@ fun LazyGridScope.playlistRows(
     onLongClick: (Playlist) -> Unit,
     showSinglePreview: Boolean = false,
     perTrackArtwork: Boolean = false,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
 ) {
     if (playlists.isEmpty()) {
         item(
@@ -68,6 +73,7 @@ fun LazyGridScope.playlistRows(
                 .take(if (showSinglePreview) 1 else 4)
                 .map { it.uri },
             perTrackArtwork = perTrackArtwork,
+            onDominantColorExtracted = onDominantColorExtracted,
             modifier = Modifier
                 .clip(ShapeDefaults.Medium)
                 .combinedClickable(
@@ -89,6 +95,7 @@ fun PlaylistRow(
     coverArtPreviewUris: List<Uri>,
     trackUris: List<Uri> = emptyList(),
     perTrackArtwork: Boolean = false,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -98,6 +105,9 @@ fun PlaylistRow(
     ) {
         val dominantColorState = rememberDominantColorState()
         val coroutineScope = rememberCoroutineScope()
+        val dominantColorCache = LocalDominantColorCache.current
+        val cachedColor = coverArtPreviewUris.firstOrNull()?.toString()
+            ?.let { dominantColorCache[it] }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
@@ -114,6 +124,13 @@ fun PlaylistRow(
                             bitmap?.let {
                                 coroutineScope.launch {
                                     dominantColorState.updateFrom(it)
+                                    val uri = coverArtPreviewUris.firstOrNull()?.toString()
+                                    if (uri != null) {
+                                        val color = dominantColorState.result?.paletteOrNull
+                                            ?.let { CoverArtColorExtractor.selectDominantColor(it) }
+                                            ?: dominantColorState.color
+                                        onDominantColorExtracted(uri, color.toArgb())
+                                    }
                                 }
                             }
                         },
@@ -144,10 +161,15 @@ fun PlaylistRow(
             )
         }
 
+        val containerColor = cachedColor?.let { Color(it) }
+            ?: dominantColorState.color
+        val contentColor = cachedColor?.let { CoverArtColorExtractor.selectOnColor(it) }
+            ?: dominantColorState.onColor
+
         TrackCountBubble(
             trackCount = trackCount,
-            contentColor = dominantColorState.onColor,
-            containerColor = dominantColorState.color
+            contentColor = contentColor,
+            containerColor = containerColor
         )
     }
 }

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/selection/SelectionCards.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/selection/SelectionCards.kt
@@ -28,9 +28,13 @@ import com.dn0ne.player.app.domain.sort.PlaylistSort
 import com.dn0ne.player.app.domain.sort.SortOrder
 import com.dn0ne.player.app.domain.sort.sortedBy
 import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.data.CoverArtColorExtractor
 import com.dn0ne.player.app.presentation.components.CoverArt
+import com.dn0ne.player.app.presentation.components.LocalDominantColorCache
 import com.dn0ne.player.app.presentation.components.playlist.FourArtsPreview
 import com.dn0ne.player.app.presentation.components.playlist.TrackCountBubble
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import com.kmpalette.rememberDominantColorState
 import kotlinx.coroutines.launch
 
@@ -43,6 +47,7 @@ fun LazyGridScope.selectionCards(
     onCardClick: (Playlist) -> Unit,
     showSinglePreview: Boolean = false,
     perTrackArtwork: Boolean = false,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
 ) {
     items(
         items = playlists.sortedBy(sort, sortOrder),
@@ -60,6 +65,7 @@ fun LazyGridScope.selectionCards(
                 .map { it.uri },
             perTrackArtwork = perTrackArtwork,
             isSelected = playlist in selectedPlaylists,
+            onDominantColorExtracted = onDominantColorExtracted,
             modifier = Modifier
                 .clip(ShapeDefaults.Large)
                 .clickable {
@@ -78,6 +84,7 @@ fun SelectionCard(
     trackUris: List<Uri> = emptyList(),
     perTrackArtwork: Boolean = false,
     isSelected: Boolean,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -88,6 +95,9 @@ fun SelectionCard(
             if (coverArtPreviewUris.size <= 1) {
                 val dominantColorState = rememberDominantColorState()
                 val coroutineScope = rememberCoroutineScope()
+                val dominantColorCache = LocalDominantColorCache.current
+                val cachedColor = coverArtPreviewUris.firstOrNull()?.toString()
+                    ?.let { dominantColorCache[it] }
                 CoverArt(
                     uri = coverArtPreviewUris.firstOrNull() ?: Uri.EMPTY,
                     trackUri = trackUris.firstOrNull(),
@@ -96,6 +106,13 @@ fun SelectionCard(
                         bitmap?.let {
                             coroutineScope.launch {
                                 dominantColorState.updateFrom(it)
+                                val uri = coverArtPreviewUris.firstOrNull()?.toString()
+                                if (uri != null) {
+                                    val color = dominantColorState.result?.paletteOrNull
+                                        ?.let { CoverArtColorExtractor.selectDominantColor(it) }
+                                        ?: dominantColorState.color
+                                    onDominantColorExtracted(uri, color.toArgb())
+                                }
                             }
                         }
                     },
@@ -104,10 +121,15 @@ fun SelectionCard(
                         .clip(ShapeDefaults.Large)
                 )
 
+                val containerColor = cachedColor?.let { Color(it) }
+                    ?: dominantColorState.color
+                val contentColor = cachedColor?.let { CoverArtColorExtractor.selectOnColor(it) }
+                    ?: dominantColorState.onColor
+
                 TrackCountBubble(
                     trackCount = trackCount,
-                    contentColor = dominantColorState.onColor,
-                    containerColor = dominantColorState.color,
+                    contentColor = contentColor,
+                    containerColor = containerColor,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .offset(y = (-4).dp)

--- a/app/src/main/java/com/dn0ne/player/app/presentation/components/selection/SelectionRows.kt
+++ b/app/src/main/java/com/dn0ne/player/app/presentation/components/selection/SelectionRows.kt
@@ -26,9 +26,13 @@ import com.dn0ne.player.app.domain.sort.PlaylistSort
 import com.dn0ne.player.app.domain.sort.SortOrder
 import com.dn0ne.player.app.domain.sort.sortedBy
 import com.dn0ne.player.app.domain.track.Playlist
+import com.dn0ne.player.app.data.CoverArtColorExtractor
 import com.dn0ne.player.app.presentation.components.CoverArt
+import com.dn0ne.player.app.presentation.components.LocalDominantColorCache
 import com.dn0ne.player.app.presentation.components.playlist.FourArtsPreview
 import com.dn0ne.player.app.presentation.components.playlist.TrackCountBubble
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import com.kmpalette.rememberDominantColorState
 import kotlinx.coroutines.launch
 
@@ -41,6 +45,7 @@ fun LazyGridScope.selectionRows(
     onRowClick: (Playlist) -> Unit,
     showSinglePreview: Boolean = false,
     perTrackArtwork: Boolean = false,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
 ) {
     items(
         items = playlists.sortedBy(sort, sortOrder),
@@ -58,6 +63,7 @@ fun LazyGridScope.selectionRows(
                 .map { it.uri },
             perTrackArtwork = perTrackArtwork,
             isSelected = playlist in selectedPlaylists,
+            onDominantColorExtracted = onDominantColorExtracted,
             modifier = Modifier
                 .clip(ShapeDefaults.Medium)
                 .clickable {
@@ -76,6 +82,7 @@ fun SelectionRow(
     trackUris: List<Uri> = emptyList(),
     perTrackArtwork: Boolean = false,
     isSelected: Boolean,
+    onDominantColorExtracted: (String, Int) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -85,6 +92,9 @@ fun SelectionRow(
     ) {
         val dominantColorState = rememberDominantColorState()
         val coroutineScope = rememberCoroutineScope()
+        val dominantColorCache = LocalDominantColorCache.current
+        val cachedColor = coverArtPreviewUris.firstOrNull()?.toString()
+            ?.let { dominantColorCache[it] }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
@@ -101,6 +111,13 @@ fun SelectionRow(
                             bitmap?.let {
                                 coroutineScope.launch {
                                     dominantColorState.updateFrom(it)
+                                    val uri = coverArtPreviewUris.firstOrNull()?.toString()
+                                    if (uri != null) {
+                                        val color = dominantColorState.result?.paletteOrNull
+                                            ?.let { CoverArtColorExtractor.selectDominantColor(it) }
+                                            ?: dominantColorState.color
+                                        onDominantColorExtracted(uri, color.toArgb())
+                                    }
                                 }
                             }
                         },
@@ -135,10 +152,15 @@ fun SelectionRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            val containerColor = cachedColor?.let { Color(it) }
+                ?: dominantColorState.color
+            val contentColor = cachedColor?.let { CoverArtColorExtractor.selectOnColor(it) }
+                ?: dominantColorState.onColor
+
             TrackCountBubble(
                 trackCount = trackCount,
-                contentColor = dominantColorState.onColor,
-                containerColor = dominantColorState.color
+                contentColor = contentColor,
+                containerColor = containerColor
             )
 
             Checkbox(

--- a/app/src/main/java/com/dn0ne/player/core/data/MusicScanner.kt
+++ b/app/src/main/java/com/dn0ne/player/core/data/MusicScanner.kt
@@ -2,23 +2,35 @@ package com.dn0ne.player.core.data
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.ContentUris
 import android.content.Context
 import android.content.Context.CLIPBOARD_SERVICE
 import android.media.MediaScannerConnection
+import android.net.Uri
+import android.os.Build
 import android.os.Environment
+import android.provider.MediaStore
 import com.dn0ne.player.R
+import com.dn0ne.player.app.data.CoverArtColorExtractor
+import com.dn0ne.player.app.data.repository.CoverArtColorRepository
 import com.dn0ne.player.app.presentation.components.snackbar.SnackbarAction
 import com.dn0ne.player.app.presentation.components.snackbar.SnackbarController
 import com.dn0ne.player.app.presentation.components.snackbar.SnackbarEvent
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 
 class MusicScanner(
     private val context: Context,
-    private val settings: Settings
+    private val settings: Settings,
+    private val coverArtColorRepository: CoverArtColorRepository,
 ) {
     private val allowedExtensions = setOf("mp3", "wav", "aac", "flac", "ogg", "m4a")
+
+    private val coverArtColorExtractor = CoverArtColorExtractor(context.contentResolver)
 
     suspend fun refreshMedia(showMessages: Boolean = true, onComplete: () -> Unit = {}) {
         withContext(Dispatchers.IO) {
@@ -73,6 +85,10 @@ class MusicScanner(
                             )
                         )
                     }
+
+                    CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+                        cacheMissingCoverArtColors()
+                    }
                 }
             } catch (e: Exception) {
                 if (!showMessages) return@withContext
@@ -114,6 +130,10 @@ class MusicScanner(
                         message = R.string.scanned_successfully
                     )
                 )
+
+                CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+                    cacheMissingCoverArtColors()
+                }
             } catch (e: Exception) {
                 SnackbarController.sendEvent(
                     SnackbarEvent(
@@ -135,6 +155,47 @@ class MusicScanner(
                 )
             }
             onComplete()
+        }
+    }
+
+    private suspend fun cacheMissingCoverArtColors() {
+        try {
+            val collection = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL)
+            } else {
+                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+            }
+
+            val albumIds = mutableSetOf<Long>()
+            context.contentResolver.query(
+                collection,
+                arrayOf(MediaStore.Audio.Media.ALBUM_ID),
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                val albumIdColumn = cursor.getColumnIndex(MediaStore.Audio.Media.ALBUM_ID)
+                if (albumIdColumn < 0) return
+                while (cursor.moveToNext()) {
+                    albumIds += cursor.getLong(albumIdColumn)
+                }
+            }
+
+            val cached = coverArtColorRepository.getCachedUris()
+            val albumArtBase = Uri.parse("content://media/external/audio/albumart")
+
+            albumIds.forEach { albumId ->
+                val coverArtUri = ContentUris.withAppendedId(albumArtBase, albumId)
+                val key = coverArtUri.toString()
+                if (key in cached) return@forEach
+
+                val color = coverArtColorExtractor.extractDominantColor(coverArtUri)
+                if (color != null) {
+                    coverArtColorRepository.cacheDominantColor(key, color)
+                }
+            }
+        } catch (e: Exception) {
+            // Not critical
         }
     }
 }

--- a/app/src/main/java/com/dn0ne/player/core/di/AppModule.kt
+++ b/app/src/main/java/com/dn0ne/player/core/di/AppModule.kt
@@ -13,7 +13,8 @@ val appModule = module {
     single<MusicScanner> {
         MusicScanner(
             context = androidContext(),
-            settings = get()
+            settings = get(),
+            coverArtColorRepository = get()
         )
     }
 }


### PR DESCRIPTION
It's now more predictable:
* tweaked the select logic so that the color makes a bit more sense now
* cache the color in the database to use it by default in the views (fixes "unstyled flashing" for dominant colors when scrolling albums)
* color now resets properly when stopping a track (there were some issues like dominant color still being active, or all dominant colors being default)