### PR TITLE
Add FFMPEG decoder

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,6 +191,7 @@ dependencies {
     implementation(libs.androidx.material.icons)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.session)
+    implementation(libs.media3.ffmpeg.decoder)
     implementation(platform(libs.koin.bom))
     implementation(libs.koin.androidx.compose)
     implementation(libs.androidx.navigation.compose)

--- a/app/src/main/java/com/dn0ne/player/PlaybackService.kt
+++ b/app/src/main/java/com/dn0ne/player/PlaybackService.kt
@@ -7,15 +7,28 @@ import android.media.AudioFormat
 import android.media.AudioTrack
 import android.media.audiofx.Equalizer
 import android.os.CountDownTimer
+import android.os.Handler
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.compose.ui.util.fastForEach
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.decoder.ffmpeg.FfmpegAudioRenderer
+import androidx.media3.decoder.ffmpeg.FfmpegLibrary
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.RenderersFactory
+import androidx.media3.exoplayer.audio.AudioRendererEventListener
+import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.metadata.MetadataOutput
+import androidx.media3.exoplayer.text.TextOutput
+import androidx.media3.exoplayer.video.VideoRendererEventListener
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import com.dn0ne.player.app.data.repository.TrackStatsRepository
@@ -216,6 +229,36 @@ class EqualizerController(context: Context) {
     }
 }
 
+@OptIn(UnstableApi::class)
+private class FfmpegRenderersFactory(context: Context) : RenderersFactory {
+    private val delegate = DefaultRenderersFactory(context)
+
+    override fun createRenderers(
+        handler: Handler,
+        videoListener: VideoRendererEventListener,
+        audioListener: AudioRendererEventListener,
+        textOutput: TextOutput,
+        metadataOutput: MetadataOutput,
+    ): Array<Renderer> {
+        val renderers = delegate.createRenderers(
+            handler,
+            videoListener,
+            audioListener,
+            textOutput,
+            metadataOutput,
+        ).toMutableList()
+
+        if (FfmpegLibrary.isAvailable()) {
+            renderers.add(
+                0,
+                FfmpegAudioRenderer(handler, audioListener, DefaultAudioSink.Builder().build()),
+            )
+        }
+
+        return renderers.toTypedArray()
+    }
+}
+
 class PlaybackService : MediaSessionService() {
     private var mediaSession: MediaSession? = null
     private val equalizerController = get<EqualizerController>()
@@ -238,7 +281,7 @@ class PlaybackService : MediaSessionService() {
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
             .build()
 
-        val player = ExoPlayer.Builder(this)
+        val player = ExoPlayer.Builder(this, FfmpegRenderersFactory(this))
             .setAudioAttributes(audioAttributes, shouldHandleAudioFocus)
             .setHandleAudioBecomingNoisy(true)
             .build()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscree
 androidx-material-icons = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "iconsExtended" }
 androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3" }
+media3-ffmpeg-decoder = { group = "org.jellyfin.media3", name = "media3-ffmpeg-decoder", version = "1.9.0+1" }
 koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koinBom" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }


### PR DESCRIPTION
Add FFMPEG decoder (prebuilt binaries from the Jellyfin project) to the ExoPlayer.
This allows to play much more file formats and codecs, e.g. ALAC.